### PR TITLE
Added ResponseBuilder.Empty() to respond to AudioPlayer requests.

### DIFF
--- a/Alexa.NET/ResponseBuilder.cs
+++ b/Alexa.NET/ResponseBuilder.cs
@@ -139,6 +139,11 @@ namespace Alexa.NET
         }
         #endregion
 
+        public static SkillResponse Empty()
+        {
+            return BuildResponse(null, true, null, null, null);
+        }
+
         #region Main Response Builder
         private static SkillResponse BuildResponse(IOutputSpeech outputSpeech, bool shouldEndSession, Session sessionAttributes, Reprompt reprompt, ICard card)
         {


### PR DESCRIPTION
Fix for https://github.com/timheuer/alexa-skills-dotnet/issues/17

Source https://forums.developer.amazon.com/questions/49211/system-error-speechletresponse-was-null.html#comment-50326

Looks like Alexa is *not* expecting `{}` but a full response JSON with zero directives and `"shouldEndSession": true`.