### PR TITLE
Remove title and content properties from LinkAccountCard as they can'…

### DIFF
--- a/Alexa.NET/ResponseBuilder.cs
+++ b/Alexa.NET/ResponseBuilder.cs
@@ -48,14 +48,14 @@ namespace Alexa.NET
             return BuildResponse(speechResponse, true, sessionAttributes, null, card);
         }
 
-        public static SkillResponse TellWithLinkAccountCard(IOutputSpeech speechResponse, string title, string content)
+        public static SkillResponse TellWithLinkAccountCard(IOutputSpeech speechResponse)
         {
             LinkAccountCard card = new LinkAccountCard();
 
             return BuildResponse(speechResponse, true, null, null, card);
         }
 
-        public static SkillResponse TellWithLinkAccountCard(IOutputSpeech speechResponse, string title, string content, Session sessionAttributes)
+        public static SkillResponse TellWithLinkAccountCard(IOutputSpeech speechResponse, Session sessionAttributes)
         {
             LinkAccountCard card = new LinkAccountCard();
 


### PR DESCRIPTION
Removed the Title and Content properties from the LinkAccountCard helper methods in ResponseBuilder. These properties can't be used by this card type.