### PR TITLE
Add tests from Slight project

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Alexa.NET\Alexa.NET.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Examples\IntentRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\LaunchRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\GetUtterance.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\NewVersionRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\Response.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\SessionEndedRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Alexa.NET.Tests/Examples/GetUtterance.json
+++ b/Alexa.NET.Tests/Examples/GetUtterance.json
@@ -1,0 +1,29 @@
+﻿{
+  "session": {
+    "sessionId": "SessionId.<snip>",
+    "application": {
+      "applicationId": "amzn1.ask.skill.<snip>"
+    },
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.ask.account.<snip>"
+    },
+    "new": true
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "EdwRequestId.<snip>",
+    "locale": "en-US",
+    "timestamp": "2016-12-06T16:39:11Z",
+    "intent": {
+      "name": "GetUtterance",
+      "slots": {
+        "Utterance": {
+          "name": "Utterance",
+          "value": "how are you"
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Alexa.NET.Tests/Examples/IntentRequest.json
+++ b/Alexa.NET.Tests/Examples/IntentRequest.json
@@ -1,0 +1,34 @@
+﻿{
+    "version": "1.0",
+    "session": {
+        "new": false,
+        "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+        "application": {
+            "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+        },
+        "attributes": {
+            "supportedHoroscopePeriods": {
+                "daily": true,
+                "weekly": false,
+                "monthly": false
+            }
+        },
+        "user": {
+            "userId": "amzn1.account.AM3B00000000000000000000000"
+        }
+    },
+    "request": {
+        "type": "IntentRequest",
+        "requestId": " amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+        "timestamp": "2015-05-13T12:34:56Z",
+        "intent": {
+            "name": "GetZodiacHoroscopeIntent",
+            "slots": {
+                "ZodiacSign": {
+                    "name": "ZodiacSign",
+                    "value": "virgo"
+                }
+            }
+        }
+    }
+}

--- a/Alexa.NET.Tests/Examples/LaunchRequest.json
+++ b/Alexa.NET.Tests/Examples/LaunchRequest.json
@@ -1,0 +1,19 @@
+﻿{
+    "version": "1.0",
+    "session": {
+        "new": true,
+        "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+        "application": {
+            "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+        },
+        "attributes": { },
+        "user": {
+            "userId": "amzn1.account.AM3B00000000000000000000000"
+        }
+    },
+    "request": {
+        "type": "LaunchRequest",
+        "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+        "timestamp": "2015-05-13T12:34:56Z"
+    }
+}

--- a/Alexa.NET.Tests/Examples/NewVersionRequest.json
+++ b/Alexa.NET.Tests/Examples/NewVersionRequest.json
@@ -1,0 +1,30 @@
+﻿{
+    "version": "1.0",
+    "newProp": "hello",
+    "newObject": {
+        "value": 1
+    },
+    "session": {
+        "new": false,
+        "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+        "application": {
+            "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+        },
+        "attributes": {
+            "supportedHoroscopePeriods": {
+                "daily": true,
+                "weekly": false,
+                "monthly": false
+            }
+        },
+        "user": {
+            "userId": "amzn1.account.AM3B00000000000000000000000"
+        }
+    },
+    "request": {
+        "type": "SessionEndedRequest",
+        "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+        "timestamp": "2015-05-13T12:34:56Z",
+        "reason": "USER_INITIATED"
+    }
+}

--- a/Alexa.NET.Tests/Examples/Response.json
+++ b/Alexa.NET.Tests/Examples/Response.json
@@ -1,0 +1,22 @@
+﻿{
+  "version": "1.0",
+  "sessionAttributes": {
+    "supportedHoriscopePeriods": {
+      "daily": true,
+      "weekly": false,
+      "monthly": false
+    }
+  },
+  "response": {
+    "outputSpeech": {
+      "type": "PlainText",
+      "text": "Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless. Can I help you with anything else?"
+    },
+    "card": {
+      "type": "Simple",
+      "title": "Horoscope",
+      "content": "Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless."
+    },
+    "shouldEndSession": false
+  }
+}

--- a/Alexa.NET.Tests/Examples/SessionEndedRequest.json
+++ b/Alexa.NET.Tests/Examples/SessionEndedRequest.json
@@ -1,0 +1,26 @@
+﻿{
+    "version": "1.0",
+    "session": {
+        "new": false,
+        "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+        "application": {
+            "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+        },
+        "attributes": {
+            "supportedHoroscopePeriods": {
+                "daily": true,
+                "weekly": false,
+                "monthly": false
+            }
+        },
+        "user": {
+            "userId": "amzn1.account.AM3B00000000000000000000000"
+        }
+    },
+    "request": {
+        "type": "SessionEndedRequest",
+        "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+        "timestamp": "2015-05-13T12:34:56Z",
+        "reason": "USER_INITIATED"
+    }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -1,0 +1,69 @@
+﻿using System.IO;
+using Alexa.NET.Request;
+using Alexa.NET.Request.Type;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Alexa.NET.Tests
+{
+    public class RequestTests
+    {
+        private string ExamplesPath = "Examples";
+
+        [Fact]
+        public void Can_read_IntentRequest_example()
+        {
+            const string example = "IntentRequest.json";
+            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
+            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+
+            Assert.NotNull(convertedObj);
+            Assert.Equal(typeof(IntentRequest), convertedObj.GetRequestType());
+        }
+
+        [Fact]
+        public void Can_read_LaunchRequest_example()
+        {
+            const string example = "LaunchRequest.json";
+            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
+            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+
+            Assert.NotNull(convertedObj);
+            Assert.Equal(typeof(LaunchRequest), convertedObj.GetRequestType());
+        }
+
+        [Fact]
+        public void Can_read_SessionEndedRequest_example()
+        {
+            const string example = "SessionEndedRequest.json";
+            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
+            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+
+            Assert.NotNull(convertedObj);
+            Assert.Equal(typeof(SessionEndedRequest), convertedObj.GetRequestType());
+        }
+
+        [Fact]
+        public void Can_read_slot_example()
+        {
+            const string example = "GetUtterance.json";
+            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
+            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+
+            var request = Assert.IsAssignableFrom<IntentRequest>(convertedObj.Request);
+            var slot = request.Intent.Slots["Utterance"];
+            Assert.Equal("how are you", slot.Value);
+        }
+
+        [Fact]
+        public void Can_accept_new_versions()
+        {
+            const string example = "SessionEndedRequest.json";
+            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
+            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+
+            Assert.NotNull(convertedObj);
+            Assert.Equal(typeof(SessionEndedRequest), convertedObj.GetRequestType());
+        }
+    }
+}

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Alexa.NET.Response;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Alexa.NET.Tests
+{
+    public class ResponseTests
+    {
+        private const string ExamplesPath = @"Examples";
+
+        [Fact]
+        public void Should_create_same_json_response_as_example()
+        {
+            var skillResponse = new SkillResponse
+            {
+                Version = "1.0",
+                SessionAttributes = new Dictionary<string, object>
+                {
+                    {
+                        "supportedHoriscopePeriods", new
+                        {
+                            daily = true,
+                            weekly = false,
+                            monthly = false
+                        }
+                    }
+                },
+                Response = new ResponseBody
+                {
+                    OutputSpeech = new PlainTextOutputSpeech
+                    {
+                        Text =
+                            "Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless. Can I help you with anything else?"
+                    },
+                    Card = new SimpleCard
+                    {
+                        Title = "Horoscope",
+                        Content =
+                            "Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless."
+                    },
+                    ShouldEndSession = false
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(skillResponse, Formatting.Indented, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            const string example = "Response.json";
+            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
+
+            workingJson = Regex.Replace(workingJson, @"\s", "");
+            json = Regex.Replace(json, @"\s", "");
+
+            Assert.Equal(workingJson, json);
+        }
+    }
+}

--- a/Alexa.NET.sln
+++ b/Alexa.NET.sln
@@ -7,6 +7,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alexa.NET", "Alexa.NET\Alexa.NET.csproj", "{C5D40122-BB51-40D8-8934-0468BCC6C92B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alexa.NET.Tests", "Alexa.NET.Tests\Alexa.NET.Tests.csproj", "{42512CDE-5E06-4D24-9467-075B0287613D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,6 +19,10 @@ Global
 		{C5D40122-BB51-40D8-8934-0468BCC6C92B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C5D40122-BB51-40D8-8934-0468BCC6C92B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C5D40122-BB51-40D8-8934-0468BCC6C92B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42512CDE-5E06-4D24-9467-075B0287613D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42512CDE-5E06-4D24-9467-075B0287613D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42512CDE-5E06-4D24-9467-075B0287613D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42512CDE-5E06-4D24-9467-075B0287613D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Alexa.NET/Response/Response.cs
+++ b/Alexa.NET/Response/Response.cs
@@ -20,5 +20,10 @@ namespace Alexa.NET.Response
 
         [JsonProperty("directives", NullValueHandling = NullValueHandling.Ignore)]
         public IList<IDirective> Directives { get; set; } = new List<IDirective>();
+
+        public bool ShouldSerializeDirectives()
+        {
+            return Directives.Count > 0;
+        }
     }
 }


### PR DESCRIPTION
Wanted to resolve #2 by moving the existing Slight tests into the root of a new XUnit project.

Updated the tests to match the new object structure

Added a "ShouldSerializeDirectives" function to ReponseBody in order to ensure that Directives is only serlalized when non-empty. This passed the original test, and ensures a clean JSON output as Directives is not a required element.

Tested running on VS for Windows, VS for Mac and CLI - all ran and passed successfully.
Obviously this is just an initial move of tests, we need more to ensure future stability - I'll endeavour to keep adding to them so we can keep this super helpful library up to date as easily as possible.

( re-submitted PR as the commits in the old one were too messy - never submit something you're not happy accepting yourself 😄  )