### PR TITLE
Standard Card content changed to output correct property

### DIFF
--- a/Alexa.NET/Response/StandardCard.cs
+++ b/Alexa.NET/Response/StandardCard.cs
@@ -16,7 +16,7 @@ namespace Alexa.NET.Response
         public string Title { get; set; }
 
         [JsonRequired]
-        [JsonProperty("content")]
+        [JsonProperty("text")]
         public string Content { get; set; }
 
         [JsonProperty("image", NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
Updated the StandardCard Json serialization for the Content property to output as "text" json property.

Amazon docs state that "content" is for simple cards and "text" is for standard cards - I've only changed the serialization attribute as it doesn't change the property purpose. In fact I'd say changing it would add to the confusion as to why Amazon decided on two different properties.

Details: [Json Reference - Card Objects](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#card-object)