### PR TITLE
Add AskForPermissionsContent card

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -35,6 +35,9 @@
     <None Update="Examples\SimpleCard.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\StandardCard.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -32,6 +32,9 @@
     <None Update="Examples\SessionEndedRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\SimpleCard.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -14,6 +14,9 @@
     <ProjectReference Include="..\Alexa.NET\Alexa.NET.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="Examples\AskForPermissionConsent.json" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="Examples\IntentRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -36,6 +39,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Examples\StandardCard.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\AskForPermissionsConsent.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Alexa.NET.Tests/CardTests.cs
+++ b/Alexa.NET.Tests/CardTests.cs
@@ -14,7 +14,7 @@ namespace Alexa.NET.Tests
         [Fact]
         public void Creates_Valid_SimpleCard()
         {
-            var actual = new SimpleCard { Title = "Example Title", Content = "Example Content" };
+            var actual = new SimpleCard { Title = ExampleTitle, Content = ExampleBodyText };
 
             Assert.True(CompareJson(actual, "SimpleCard.json"));
         }
@@ -22,13 +22,25 @@ namespace Alexa.NET.Tests
         [Fact]
         public void Creates_Valid_StandardCard()
         {
-            var actual = new StandardCard{Title="Example Title",}
+            var cardImages = new CardImage { SmallImageUrl = "https://example.com/smallImage.png", LargeImageUrl = "https://example.com/largeImage.png" };
+            var actual = new StandardCard{ Title = ExampleTitle, Content = ExampleBodyText,Image=cardImages };
+
+            Assert.True(CompareJson(actual, "StandardCard.json"));
+        }
+
+        [Fact]
+        public void Creates_Valid_AskForPermissionConsent()
+        {
+            var actual = new AskForPermissionsConsentCard();
+            actual.Permissions.Add(RequestedPermission.ReadHouseholdList);
+
+            Assert.True(CompareJson(actual, "AskForPermissionsConsent.json"));
         }
 
         private bool CompareJson(object actual, string expectedFile)
         {
+            
             var actualJObject = JObject.FromObject(actual);
-
             var expected = File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
             var expectedJObject = JObject.Parse(expected);
 

--- a/Alexa.NET.Tests/CardTests.cs
+++ b/Alexa.NET.Tests/CardTests.cs
@@ -8,6 +8,8 @@ namespace Alexa.NET.Tests
     public class CardTests
     {
         private const string ExamplesPath = "Examples";
+        private const string ExampleTitle = "Example Title";
+        private const string ExampleBodyText = "Example Body Text";
 
         [Fact]
         public void Creates_Valid_SimpleCard()
@@ -15,6 +17,12 @@ namespace Alexa.NET.Tests
             var actual = new SimpleCard { Title = "Example Title", Content = "Example Content" };
 
             Assert.True(CompareJson(actual, "SimpleCard.json"));
+        }
+
+        [Fact]
+        public void Creates_Valid_StandardCard()
+        {
+            var actual = new StandardCard{Title="Example Title",}
         }
 
         private bool CompareJson(object actual, string expectedFile)

--- a/Alexa.NET.Tests/CardTests.cs
+++ b/Alexa.NET.Tests/CardTests.cs
@@ -1,0 +1,30 @@
+﻿using Xunit;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using Alexa.NET.Response;
+
+namespace Alexa.NET.Tests
+{
+    public class CardTests
+    {
+        private const string ExamplesPath = "Examples";
+
+        [Fact]
+        public void Creates_Valid_SimpleCard()
+        {
+            var actual = new SimpleCard { Title = "Example Title", Content = "Example Content" };
+
+            Assert.True(CompareJson(actual, "SimpleCard.json"));
+        }
+
+        private bool CompareJson(object actual, string expectedFile)
+        {
+            var actualJObject = JObject.FromObject(actual);
+
+            var expected = File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
+            var expectedJObject = JObject.Parse(expected);
+
+            return JToken.DeepEquals(expectedJObject, actualJObject);
+        }
+    }
+}

--- a/Alexa.NET.Tests/Examples/AskForPermissionsConsent.json
+++ b/Alexa.NET.Tests/Examples/AskForPermissionsConsent.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "AskForPermissionsConsent",
+  "permissions": [
+    "read::alexa:household:list"
+  ]
+}

--- a/Alexa.NET.Tests/Examples/SimpleCard.json
+++ b/Alexa.NET.Tests/Examples/SimpleCard.json
@@ -1,0 +1,5 @@
+﻿{
+  "type": "Simple",
+  "title": "Example Title",
+  "content": "Example Content"
+}

--- a/Alexa.NET.Tests/Examples/SimpleCard.json
+++ b/Alexa.NET.Tests/Examples/SimpleCard.json
@@ -1,5 +1,5 @@
 ﻿{
   "type": "Simple",
   "title": "Example Title",
-  "content": "Example Content"
+  "content": "Example Body Text"
 }

--- a/Alexa.NET.Tests/Examples/StandardCard.json
+++ b/Alexa.NET.Tests/Examples/StandardCard.json
@@ -1,0 +1,9 @@
+﻿{
+  "type": "Standard",
+  "title": "Example Title",
+  "content": "Example Body Text",
+  "image": {
+    "smallImageUrl": "https://example.com/smallImage.png",
+    "largeImageUrl": "https://example.com/largeImage.png"
+  }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -8,14 +8,12 @@ namespace Alexa.NET.Tests
 {
     public class RequestTests
     {
-        private string ExamplesPath = "Examples";
+        private const string ExamplesPath = "Examples";
 
         [Fact]
         public void Can_read_IntentRequest_example()
         {
-            const string example = "IntentRequest.json";
-            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
-            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+            var convertedObj = GetObjectFromExample<SkillRequest>("IntentRequest.json");
 
             Assert.NotNull(convertedObj);
             Assert.Equal(typeof(IntentRequest), convertedObj.GetRequestType());
@@ -24,9 +22,7 @@ namespace Alexa.NET.Tests
         [Fact]
         public void Can_read_LaunchRequest_example()
         {
-            const string example = "LaunchRequest.json";
-            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
-            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+            var convertedObj = GetObjectFromExample<SkillRequest>("LaunchRequest.json");
 
             Assert.NotNull(convertedObj);
             Assert.Equal(typeof(LaunchRequest), convertedObj.GetRequestType());
@@ -35,9 +31,7 @@ namespace Alexa.NET.Tests
         [Fact]
         public void Can_read_SessionEndedRequest_example()
         {
-            const string example = "SessionEndedRequest.json";
-            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
-            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+            var convertedObj = GetObjectFromExample<SkillRequest>("SessionEndedRequest.json");
 
             Assert.NotNull(convertedObj);
             Assert.Equal(typeof(SessionEndedRequest), convertedObj.GetRequestType());
@@ -46,9 +40,7 @@ namespace Alexa.NET.Tests
         [Fact]
         public void Can_read_slot_example()
         {
-            const string example = "GetUtterance.json";
-            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
-            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+            var convertedObj = GetObjectFromExample<SkillRequest>("GetUtterance.json");
 
             var request = Assert.IsAssignableFrom<IntentRequest>(convertedObj.Request);
             var slot = request.Intent.Slots["Utterance"];
@@ -58,12 +50,16 @@ namespace Alexa.NET.Tests
         [Fact]
         public void Can_accept_new_versions()
         {
-            const string example = "SessionEndedRequest.json";
-            var json = File.ReadAllText(Path.Combine(ExamplesPath, example));
-            var convertedObj = JsonConvert.DeserializeObject<SkillRequest>(json);
+            var convertedObj = GetObjectFromExample<SkillRequest>("SessionEndedRequest.json");
 
             Assert.NotNull(convertedObj);
             Assert.Equal(typeof(SessionEndedRequest), convertedObj.GetRequestType());
+        }
+
+        private T GetObjectFromExample<T>(string filename)
+        {
+            var json = File.ReadAllText(Path.Combine(ExamplesPath, filename));
+            return JsonConvert.DeserializeObject<T>(json);
         }
     }
 }

--- a/Alexa.NET/Response/AskForPermissionsConsentCard.cs
+++ b/Alexa.NET/Response/AskForPermissionsConsentCard.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+namespace Alexa.NET.Response
+{
+    public class AskForPermissionsConsentCard : ICard
+    {
+
+        [JsonProperty("type")]
+        [JsonRequired]
+        public string Type
+        {
+            get { return "AskForPermissionsConsent"; }
+        }
+
+        [JsonProperty("permissions")]
+        [JsonRequired]
+        public List<string> Permissions { get; set; } = new List<string>();
+    }
+}

--- a/Alexa.NET/Response/RequestedPermission.cs
+++ b/Alexa.NET/Response/RequestedPermission.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace Alexa.NET.Response
+{
+    public static class RequestedPermission
+    {
+        public const string ReadHouseholdList  = "read::alexa:household:list";
+        public const string WriteHouseholdList = "write::alexa:household:list";
+    }
+}

--- a/Alexa.NET/ResponseBuilder.cs
+++ b/Alexa.NET/ResponseBuilder.cs
@@ -61,6 +61,21 @@ namespace Alexa.NET
 
             return BuildResponse(speechResponse, true, sessionAttributes, null, card);
         }
+
+        public static SkillResponse TellWithAskForPermissionsConsentCard(IOutputSpeech speechResponse,IEnumerable<string> permissions)
+        {
+            AskForPermissionsConsentCard card = new AskForPermissionsConsentCard();
+            card.Permissions = permissions.ToList();
+            return BuildResponse(speechResponse, true, null, null, card);
+        }
+
+        public static SkillResponse TellWithAskForPermissionsConsentCard(IOutputSpeech speechResponse, IEnumerable<string> permissions, Session sessionAttributes)
+        {
+			AskForPermissionsConsentCard card = new AskForPermissionsConsentCard();
+			card.Permissions = permissions.ToList();
+            return BuildResponse(speechResponse, true, sessionAttributes, null, card);
+        }
+
         #endregion
 
         #region Ask Responses


### PR DESCRIPTION
Added AskForPermissionsConsentCard - used when asking for access to Alexa lists from a custom Skill.

Added ResponseBuilder helper methods to use the new card

Added CardTests to ensure output matches expectations.

Refactored existing tests to remove duplication of arrange test step.

Details: [Accessing the Alexa shopping and todo lists](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/access-the-alexa-shopping-and-to-do-lists#missing_permissions)