### PR TITLE
Entity Resolution Support

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -44,6 +44,12 @@
     <None Update="Examples\AskForPermissionsConsent.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\Resolution.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\IntentWithResolution.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Alexa.NET.Tests/Examples/IntentWithResolution.json
+++ b/Alexa.NET.Tests/Examples/IntentWithResolution.json
@@ -1,0 +1,52 @@
+﻿{
+  "type": "IntentRequest",
+  "intent": {
+    "name": "GetMediaIntent",
+    "slots": {
+      "MediaType": {
+        "name": "MediaType",
+        "value": "song",
+        "resolutions": {
+          "resolutionsPerAuthority": [
+            {
+              "authority": "amzn1.er-authority.echo-sdk.<skill_id>.MEDIA_TYPE",
+              "status": {
+                "code": "ER_SUCCESS_MATCH"
+              },
+              "values": [
+                {
+                  "value": {
+                    "name": "song",
+                    "id": "SONG"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "MediaTitle": {
+        "name": "MediaTitle",
+        "value": "rolling in the deep",
+        "resolutions": {
+          "resolutionsPerAuthority": [
+            {
+              "authority": "amzn1.er-authority.echo-sdk.<skill_id>.MEDIA_TITLE",
+              "status": {
+                "code": "ER_SUCCESS_MATCH"
+              },
+              "values": [
+                {
+                  "value": {
+                    "name": "Rolling in the Deep",
+                    "id": "song_id_456"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/Alexa.NET.Tests/Examples/Resolution.json
+++ b/Alexa.NET.Tests/Examples/Resolution.json
@@ -1,0 +1,18 @@
+﻿{
+  "resolutionsPerAuthority": [
+    {
+      "authority": "amzn1.er-authority.echo-sdk.<skill_id>.MEDIA_TYPE",
+      "status": {
+        "code": "ER_SUCCESS_MATCH"
+      },
+      "values": [
+        {
+          "value": {
+            "name": "song",
+            "id": "SONG"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -81,8 +81,7 @@ namespace Alexa.NET.Tests
         [Fact]
         public void Can_read_intent_with_entity_resolution()
         {
-            var convertedObj = GetObjectFromExample<SkillRequest>("IntentWithResolution.json");
-            var intentRequest = (IntentRequest)convertedObj.Request;
+            var intentRequest = GetObjectFromExample<IntentRequest>("IntentWithResolution.json");
             var mediaTypeSlot = intentRequest.Intent.Slots["MediaType"];
             var mediaTitleSlot = intentRequest.Intent.Slots["MediaTitle"];
 

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -2,6 +2,7 @@
 using Alexa.NET.Request;
 using Alexa.NET.Request.Type;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Alexa.NET.Tests
@@ -54,6 +55,95 @@ namespace Alexa.NET.Tests
 
             Assert.NotNull(convertedObj);
             Assert.Equal(typeof(SessionEndedRequest), convertedObj.GetRequestType());
+        }
+
+        [Fact]
+        public void Can_read_resolution()
+        {
+            var actual = new Resolution
+            {
+                Authorities = new[]{
+                    new ResolutionAuthority{
+                        Name="amzn1.er-authority.echo-sdk.<skill_id>.MEDIA_TYPE",
+                        Status=new ResolutionStatus{Code=ResolutionStatusCode.SuccessfulMatch},
+                        Values=new []{
+                            new ResolutionValueContainer{Value=
+                                new ResolutionValue{Name="song",Id="SONG"}
+                            }
+                        }
+                    }
+                }
+            };
+
+            Assert.True(CompareJson(actual, "Resolution.json"));
+        }
+
+        [Fact]
+        public void Can_read_intent_with_entity_resolution()
+        {
+            var convertedObj = GetObjectFromExample<SkillRequest>("IntentWithResolution.json");
+            var intentRequest = (IntentRequest)convertedObj.Request;
+            var mediaTypeSlot = intentRequest.Intent.Slots["MediaType"];
+            var mediaTitleSlot = intentRequest.Intent.Slots["MediaTitle"];
+
+            var mediaTypeResolutionAuthority = new Resolution
+            {
+                Authorities = new[]{
+                    new ResolutionAuthority{
+                        Name="amzn1.er-authority.echo-sdk.<skill_id>.MEDIA_TYPE",
+                        Status = new ResolutionStatus{Code=ResolutionStatusCode.SuccessfulMatch},
+                        Values= new[]{
+                            new ResolutionValueContainer{Value = new ResolutionValue{
+                                    Name="song",
+                                    Id="SONG"
+                                }
+                            }
+                    }
+                }
+                }
+            };
+
+			var mediaTitleResolutionAuthority = new Resolution
+			{
+				Authorities = new[]{
+					new ResolutionAuthority{
+						Name="amzn1.er-authority.echo-sdk.<skill_id>.MEDIA_TITLE",
+						Status = new ResolutionStatus{Code=ResolutionStatusCode.SuccessfulMatch},
+						Values= new[]{
+							new ResolutionValueContainer{Value = new ResolutionValue{
+									Name="Rolling in the Deep",
+									Id="song_id_456"
+								}
+							}
+					}
+				}
+				}
+			};
+
+
+
+            Assert.True(CompareJson(mediaTypeSlot.Resolution, mediaTypeResolutionAuthority));
+            Assert.True(CompareJson(mediaTitleSlot.Resolution, mediaTitleResolutionAuthority));
+        }
+
+
+        private bool CompareJson(object actual, object expected)
+        {
+
+            var actualJObject = JObject.FromObject(actual);
+            var expectedJObject = JObject.FromObject(expected);
+
+            return JToken.DeepEquals(expectedJObject, actualJObject);
+        }
+
+        private bool CompareJson(object actual, string expectedFile)
+        {
+
+            var actualJObject = JObject.FromObject(actual);
+            var expected = File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
+            var expectedJObject = JObject.Parse(expected);
+
+            return JToken.DeepEquals(expectedJObject, actualJObject);
         }
 
         private T GetObjectFromExample<T>(string filename)

--- a/Alexa.NET/Request/Resolution.cs
+++ b/Alexa.NET/Request/Resolution.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class Resolution
+    {
+        [JsonProperty("resolutionsPerAuthority")]
+        public ResolutionAuthority[] Authorities { get; set; }
+    }
+}

--- a/Alexa.NET/Request/ResolutionAuthority.cs
+++ b/Alexa.NET/Request/ResolutionAuthority.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class ResolutionAuthority
+    {
+        [JsonProperty("authority")]
+        public string Name { get; set; }
+
+        [JsonProperty("status")]
+        public ResolutionStatus Status { get; set; }
+
+        [JsonProperty("values")]
+        public ResolutionValueContainer[] Values { get; set; }
+    }
+}

--- a/Alexa.NET/Request/ResolutionStatus.cs
+++ b/Alexa.NET/Request/ResolutionStatus.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class ResolutionStatus
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+    }
+}

--- a/Alexa.NET/Request/ResolutionStatusCode.cs
+++ b/Alexa.NET/Request/ResolutionStatusCode.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Alexa.NET.Request
+{
+    public static class ResolutionStatusCode
+    {
+        public const string SuccessfulMatch = "ER_SUCCESS_MATCH";
+        public const string NoMatch = "ER_SUCCESS_NO_MATCH";
+        public const string Timeout = "ER_ERROR_TIMEOUT";
+        public const string Exception = "ER_ERROR_EXCEPTION";
+	}
+}

--- a/Alexa.NET/Request/ResolutionValue.cs
+++ b/Alexa.NET/Request/ResolutionValue.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class ResolutionValue
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/Alexa.NET/Request/ResolutionValueContainer.cs
+++ b/Alexa.NET/Request/ResolutionValueContainer.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class ResolutionValueContainer
+    {
+        [JsonProperty("value")]
+        public ResolutionValue Value { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Slot.cs
+++ b/Alexa.NET/Request/Slot.cs
@@ -9,5 +9,8 @@ namespace Alexa.NET.Request
 
         [JsonProperty("value")]
         public string Value { get; set; }
+
+        [JsonProperty("resolutions")]
+        public Resolution Resolution { get; set; }
     }
 }


### PR DESCRIPTION
Amazon have announced entity resolution - the ability for a combination of synonyms to be resolved to a single entity rather than having to attempt to do it in code.

This PR defines an object model for the new Resolution structure within Intent Slots, as well as adds a few new tests to ensure the model is parsed as expected.

References:
[Announcing Alexa Entity Resolution](https://developer.amazon.com/blogs/alexa/post/5de2b24d-d932-4c6f-950d-d09d8ffdf4d4/entity-resolution-and-slot-validation)
[Updated IntentRequest JSON structure with resolutions](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/custom-standard-request-types-reference#intentrequest)
[New Resolution Object description](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/custom-standard-request-types-reference#resolutions-object)