### PR TITLE
Add VideoApp interface support

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -68,6 +68,12 @@
     <None Update="Examples\DialogConfirmSlot.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\VideoAppDirective.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\VideoAppDirectiveWithMetadata.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Alexa.NET.Tests/CardTests.cs
+++ b/Alexa.NET.Tests/CardTests.cs
@@ -7,7 +7,6 @@ namespace Alexa.NET.Tests
 {
     public class CardTests
     {
-        private const string ExamplesPath = "Examples";
         private const string ExampleTitle = "Example Title";
         private const string ExampleBodyText = "Example Body Text";
 
@@ -16,7 +15,7 @@ namespace Alexa.NET.Tests
         {
             var actual = new SimpleCard { Title = ExampleTitle, Content = ExampleBodyText };
 
-            Assert.True(CompareJson(actual, "SimpleCard.json"));
+            Assert.True(Utility.CompareJson(actual, "SimpleCard.json"));
         }
 
         [Fact]
@@ -25,7 +24,7 @@ namespace Alexa.NET.Tests
             var cardImages = new CardImage { SmallImageUrl = "https://example.com/smallImage.png", LargeImageUrl = "https://example.com/largeImage.png" };
             var actual = new StandardCard{ Title = ExampleTitle, Content = ExampleBodyText,Image=cardImages };
 
-            Assert.True(CompareJson(actual, "StandardCard.json"));
+            Assert.True(Utility.CompareJson(actual, "StandardCard.json"));
         }
 
         [Fact]
@@ -34,17 +33,7 @@ namespace Alexa.NET.Tests
             var actual = new AskForPermissionsConsentCard();
             actual.Permissions.Add(RequestedPermission.ReadHouseholdList);
 
-            Assert.True(CompareJson(actual, "AskForPermissionsConsent.json"));
-        }
-
-        private bool CompareJson(object actual, string expectedFile)
-        {
-            
-            var actualJObject = JObject.FromObject(actual);
-            var expected = File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
-            var expectedJObject = JObject.Parse(expected);
-
-            return JToken.DeepEquals(expectedJObject, actualJObject);
+            Assert.True(Utility.CompareJson(actual, "AskForPermissionsConsent.json"));
         }
     }
 }

--- a/Alexa.NET.Tests/DialogDirectiveTests.cs
+++ b/Alexa.NET.Tests/DialogDirectiveTests.cs
@@ -9,14 +9,12 @@ namespace Alexa.NET.Tests
 {
     public class DialogDirectiveTests
     {
-        private const string ExamplesPath = "Examples";
-
         [Fact]
         public void Create_Valid_DialogDelegateDirective()
         {
             var actual = new DialogDelegate{UpdatedIntent=GetUpdatedIntent()};
 
-            Assert.True(CompareJson(actual, "DialogDelegate.json"));
+            Assert.True(Utility.CompareJson(actual, "DialogDelegate.json"));
         }
 
         [Fact]
@@ -24,7 +22,7 @@ namespace Alexa.NET.Tests
         {
             var actual = new DialogElicitSlot("ZodiacSign") { UpdatedIntent = GetUpdatedIntent() };
 
-			Assert.True(CompareJson(actual, "DialogElicitSlot.json"));
+			Assert.True(Utility.CompareJson(actual, "DialogElicitSlot.json"));
         }
 
 		[Fact]
@@ -32,7 +30,7 @@ namespace Alexa.NET.Tests
 		{
 			var actual = new DialogConfirmSlot("Date") { UpdatedIntent = GetUpdatedIntent() };
 
-			Assert.True(CompareJson(actual, "DialogConfirmSlot.json"));
+			Assert.True(Utility.CompareJson(actual, "DialogConfirmSlot.json"));
 		}
 
         [Fact]
@@ -41,7 +39,7 @@ namespace Alexa.NET.Tests
             var actual = new DialogConfirmIntent { UpdatedIntent = GetUpdatedIntent() };
             actual.UpdatedIntent.Slots["ZodiacSign"].ConfirmationStatus = ConfirmationStatus.Confirmed;
 
-            Assert.True(CompareJson(actual, "DialogConfirmIntent.json"));
+            Assert.True(Utility.CompareJson(actual, "DialogConfirmIntent.json"));
         }
 
         private Intent GetUpdatedIntent()
@@ -55,16 +53,6 @@ namespace Alexa.NET.Tests
 						{"Date",new Slot{Name="Date",Value="2015-11-25",ConfirmationStatus=ConfirmationStatus.Confirmed}}
 				}
 			};
-        }
-
-        private bool CompareJson(object actual, string expectedFile)
-        {
-
-            var actualJObject = JObject.FromObject(actual);
-            var expected = File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
-            var expectedJObject = JObject.Parse(expected);
-            Console.WriteLine(actualJObject);
-            return JToken.DeepEquals(expectedJObject, actualJObject);
         }
     }
 }

--- a/Alexa.NET.Tests/Examples/VideoAppDirective.json
+++ b/Alexa.NET.Tests/Examples/VideoAppDirective.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "VideoApp.Launch",
+  "videoItem": {
+    "source": "https://www.example.com/video/sample-video-1.mp4"
+  }
+}	

--- a/Alexa.NET.Tests/Examples/VideoAppDirectiveWithMetadata.json
+++ b/Alexa.NET.Tests/Examples/VideoAppDirectiveWithMetadata.json
@@ -1,0 +1,10 @@
+﻿{
+	"type": "VideoApp.Launch",
+	"videoItem": {
+		"source": "https://www.example.com/video/sample-video-1.mp4",
+		"metadata": {
+			"title": "Title for Sample Video",
+			"subtitle": "Secondary Title for Sample Video"
+		}
+	}
+}	

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -156,12 +156,12 @@ namespace Alexa.NET.Tests
 
 
 
-            Assert.True(CompareJson(mediaTypeSlot.Resolution, mediaTypeResolutionAuthority));
-            Assert.True(CompareJson(mediaTitleSlot.Resolution, mediaTitleResolutionAuthority));
+            Assert.True(CompareObjectJson(mediaTypeSlot.Resolution, mediaTypeResolutionAuthority));
+            Assert.True(CompareObjectJson(mediaTitleSlot.Resolution, mediaTitleResolutionAuthority));
         }
 
 
-        private bool CompareJson(object actual, object expected)
+        private bool CompareObjectJson(object actual, object expected)
         {
 
             var actualJObject = JObject.FromObject(actual);

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text.RegularExpressions;
 using Alexa.NET.Response;
+using Alexa.NET.Response.Directive;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Xunit;
@@ -58,6 +59,29 @@ namespace Alexa.NET.Tests
             json = Regex.Replace(json, @"\s", "");
 
             Assert.Equal(workingJson, json);
+        }
+
+        [Fact]
+        public void Creates_VideoAppDirective()
+        {
+            var videoItem = new VideoItem("https://www.example.com/video/sample-video-1.mp4")
+            {
+                Metadata = new VideoItemMetadata
+                {
+                    Title = "Title for Sample Video",
+                    Subtitle = "Secondary Title for Sample Video"
+                }
+            };
+            var actual = new VideoAppDirective{VideoItem=videoItem};
+
+            Assert.True(Utility.CompareJson(actual, "VideoAppDirectiveWithMetadata.json"));
+        }
+
+        [Fact]
+        public void Create_VideoAppDirective_FromSource()
+        {
+            var actual = new VideoAppDirective("https://www.example.com/video/sample-video-1.mp4");
+            Assert.True(Utility.CompareJson(actual, "VideoAppDirective.json"));
         }
     }
 }

--- a/Alexa.NET.Tests/Utility.cs
+++ b/Alexa.NET.Tests/Utility.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.Tests
+{
+    public static class Utility
+    {
+        private const string ExamplesPath = "Examples";
+
+        public static bool CompareJson(object actual, string expectedFile)
+        {
+            var actualJObject = JObject.FromObject(actual);
+            var expected = File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
+            var expectedJObject = JObject.Parse(expected);
+            Console.WriteLine(actualJObject);
+            return JToken.DeepEquals(expectedJObject, actualJObject);
+        }
+    }
+}

--- a/Alexa.NET/Request/SupportedInterfaces.cs
+++ b/Alexa.NET/Request/SupportedInterfaces.cs
@@ -5,8 +5,10 @@ using System.Threading.Tasks;
 
 namespace Alexa.NET.Request
 {
-    public class SupportedInterfaces
+    public static class SupportedInterfaces
     {
-        
+        public const string Display = "Display";
+        public const string AudioPlayer = "AudioPlayer";
+        public const string VideoApp = "VideoApp";
     }
 }

--- a/Alexa.NET/Response/Directive/VideoAppDirective.cs
+++ b/Alexa.NET/Response/Directive/VideoAppDirective.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class VideoAppDirective:IDirective
+    {
+        public VideoAppDirective()
+        {
+        }
+
+        public VideoAppDirective(string source)
+        {
+            VideoItem = new VideoItem(source);
+        }
+
+        [JsonProperty("type")]
+        public string Type => "VideoApp.Launch";
+
+        [JsonProperty("videoItem",Required = Required.Always)]
+        public VideoItem VideoItem { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Directive/VideoItem.cs
+++ b/Alexa.NET/Response/Directive/VideoItem.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class VideoItem
+    {
+        public VideoItem(string source)
+        {
+            Source = source;
+        }
+
+        [JsonProperty("source", Required = Required.Always)]
+        public string Source { get; set; }
+
+        [JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]
+        public VideoItemMetadata Metadata { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Directive/VideoItemMetadata.cs
+++ b/Alexa.NET/Response/Directive/VideoItemMetadata.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class VideoItemMetadata
+    {
+        [JsonProperty("title",NullValueHandling = NullValueHandling.Ignore)]
+        public string Title { get; set; }
+
+        [JsonProperty("subtitle", NullValueHandling = NullValueHandling.Ignore)]
+        public string Subtitle { get; set; }
+    }
+}


### PR DESCRIPTION
- Add support for the VideoApp.Launch directive, one of the new directives added for devices such as the Amazon Echo Show.
- Add tests for the VideoApp directive.
- Move CompareJson test method into a utility class as almost all the tests use it.

**Reference:**
[VideoApp Interface Reference](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/videoapp-interface-reference)
