### PR TITLE
Timestamp fix

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -68,6 +68,9 @@
     <None Update="Examples\DialogConfirmSlot.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\LaunchRequestWithEpochTimestamp.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Alexa.NET.Tests/DialogDirectiveTests.cs
+++ b/Alexa.NET.Tests/DialogDirectiveTests.cs
@@ -63,7 +63,6 @@ namespace Alexa.NET.Tests
             var actualJObject = JObject.FromObject(actual);
             var expected = File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
             var expectedJObject = JObject.Parse(expected);
-            Console.WriteLine(actualJObject);
             return JToken.DeepEquals(expectedJObject, actualJObject);
         }
     }

--- a/Alexa.NET.Tests/Examples/LaunchRequestWithEpochTimestamp.json
+++ b/Alexa.NET.Tests/Examples/LaunchRequestWithEpochTimestamp.json
@@ -1,0 +1,19 @@
+﻿{
+  "version": "1.0",
+  "session": {
+    "new": true,
+    "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+    },
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.account.AM3B00000000000000000000000"
+    }
+  },
+  "request": {
+    "type": "LaunchRequest",
+    "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": 1499590645
+  }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -65,6 +65,15 @@ namespace Alexa.NET.Tests
         }
 
         [Fact]
+        public void Can_read_LaunchRequestWithEpochTimestamp_example()
+        {
+			var convertedObj = GetObjectFromExample<SkillRequest>("LaunchRequestWithEpochTimestamp.json");
+
+			Assert.NotNull(convertedObj);
+			Assert.Equal(typeof(LaunchRequest), convertedObj.GetRequestType()); 
+        }
+
+        [Fact]
         public void Can_read_SessionEndedRequest_example()
         {
             var convertedObj = GetObjectFromExample<SkillRequest>("SessionEndedRequest.json");

--- a/Alexa.NET/Request/IntentSignature.cs
+++ b/Alexa.NET/Request/IntentSignature.cs
@@ -83,13 +83,10 @@ namespace Alexa.NET.Request
 
             string propertyPiece = action.Substring(propertyPoint+1, action.Length - (propertyPoint+2));
 
-            Console.WriteLine(propertyPiece);
-
             IDictionary<string, IntentProperty> propertyDictionary = new Dictionary<string, IntentProperty>();
 
             foreach (Match match in PropertyFinder.Matches(propertyPiece))
             {
-                Console.WriteLine(match.Value);
                 propertyDictionary.Add(
                     match.Groups[1].Value,
                     new IntentProperty(match.Groups[2].Value,match.Groups[4].Value)

--- a/Alexa.NET/Request/Type/MixedDateTimeConverter.cs
+++ b/Alexa.NET/Request/Type/MixedDateTimeConverter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Newtonsoft.Json;
+
+
+namespace Alexa.NET.Request.Type
+{
+	public class MixedDateTimeConverter : Newtonsoft.Json.Converters.DateTimeConverterBase
+    {
+		static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			
+		}
+
+		public override object ReadJson(JsonReader reader, System.Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if(reader.ValueType == typeof(DateTime))
+            {
+                return reader.Value;
+            }
+
+            if(reader.ValueType == typeof(long))
+            {
+                return UtcFromEpoch((long)reader.Value);
+            }
+
+			if (reader.ValueType == typeof(String))
+			{
+                return DateTime.Parse(reader.Value.ToString());
+			}
+			return UtcFromEpoch(((long)reader.Value));
+		}
+
+		private DateTime UtcFromEpoch(long epochTime)
+		{
+			return UnixEpoch.AddSeconds(epochTime);
+		}
+	}
+}

--- a/Alexa.NET/Request/Type/Request.cs
+++ b/Alexa.NET/Request/Type/Request.cs
@@ -14,7 +14,7 @@ namespace Alexa.NET.Request.Type
         [JsonProperty("locale")]
         public string Locale { get; set; }
 
-        [JsonProperty("timestamp")]
+        [JsonProperty("timestamp"),JsonConverter(typeof(MixedDateTimeConverter))]
         public DateTime Timestamp { get; set; }
     }
 }


### PR DESCRIPTION
- Add a datetime converter to handle multiple date types. This should resolve #36 and ensure that it remains fixed regardless of if it should revert/reoccur.

- Added a test to RequestTests to ensure epoch timestamps in the request can be handled alongside the standard string format.

- Also removed Console.WriteLine statements from the codebase as it was making the test results difficult to read, and should only have been there while I was debugging them anyway.