### PR TITLE
Service Sim sends epoch time in ms.

### DIFF
--- a/Alexa.NET.Tests/Examples/LaunchRequestWithEpochTimestamp.json
+++ b/Alexa.NET.Tests/Examples/LaunchRequestWithEpochTimestamp.json
@@ -14,6 +14,6 @@
   "request": {
     "type": "LaunchRequest",
     "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
-    "timestamp": 1499590645
+    "timestamp": 1431520496000
   }
 }

--- a/Alexa.NET/Helpers/MixedDateTimeConverter.cs
+++ b/Alexa.NET/Helpers/MixedDateTimeConverter.cs
@@ -35,7 +35,7 @@ namespace Alexa.NET.Helpers
 
 		private DateTime UtcFromEpoch(long epochTime)
 		{
-			return UnixEpoch.AddSeconds(epochTime);
+			return UnixEpoch.AddMilliseconds(epochTime);
 		}
 	}
 }


### PR DESCRIPTION
I'm not sure if Service Sim sent epoch time in seconds when this code was added. If it was, we may want to add some sort of assumption check to choose between `UnixEpoch.AddSeconds` and `UnixEpoch.AddMilliseconds`.

Fixes #38 