### PR TITLE
Skill event support

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -44,6 +44,15 @@
     <None Update="Examples\SimpleCard.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\SkillEventAccountLink.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\SkillEventEnabled.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\SkillEventPermissionChange.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\StandardCard.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Examples/SkillEventAccountLink.json
+++ b/Alexa.NET.Tests/Examples/SkillEventAccountLink.json
@@ -1,0 +1,26 @@
+﻿{
+  "version": "string",
+  "context": {
+    "System": {
+      "application": {
+        "applicationId": "string"
+      },
+      "user": {
+        "userId": "string",
+        "accessToken": "string",
+        "permissions": {
+          "consentToken": "string"
+        }
+      },
+      "apiEndpoint": "https://api.amazonalexa.com"
+    }
+  },
+  "request": {
+    "type": "AlexaSkillEvent.SkillAccountLinked",
+    "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "body": {
+      "accessToken": "testToken"
+    }
+  }
+}

--- a/Alexa.NET.Tests/Examples/SkillEventEnabled.json
+++ b/Alexa.NET.Tests/Examples/SkillEventEnabled.json
@@ -1,0 +1,19 @@
+﻿{
+  "version": "string",
+  "context": {
+    "System": {
+      "application": {
+        "applicationId": "string"
+      },
+      "user": {
+        "userId": "string"
+      },
+      "apiEndpoint": "https://api.amazonalexa.com"
+    }
+  },
+  "request": {
+    "type": "AlexaSkillEvent.SkillEnabled",
+    "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": "2015-05-13T12:34:56Z"
+  }
+}

--- a/Alexa.NET.Tests/Examples/SkillEventPermissionChange.json
+++ b/Alexa.NET.Tests/Examples/SkillEventPermissionChange.json
@@ -1,0 +1,30 @@
+﻿{
+  "version": "string",
+  "context": {
+    "System": {
+      "application": {
+        "applicationId": "string"
+      },
+      "user": {
+        "userId": "string",
+        "accessToken": "string",
+        "permissions":{ 
+          "consentToken":"string"
+        }
+      },
+      "apiEndpoint": "https://api.amazonalexa.com"
+    }
+  },
+	"request": {
+		"type": "AlexaSkillEvent.SkillPermissionAccepted",
+		"requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+		"timestamp": "2015-05-13T12:34:56Z",
+		"body": {
+			"acceptedPermissions": [
+				{
+					"scope": "testScope"
+				}
+			]
+		}
+	}
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -169,6 +169,28 @@ namespace Alexa.NET.Tests
             Assert.True(CompareObjectJson(mediaTitleSlot.Resolution, mediaTitleResolutionAuthority));
         }
 
+        [Fact]
+        public void Can_Read_SkillEventAccountLink()
+        {
+            var convertedObj = GetObjectFromExample<SkillRequest>("SkillEventAccountLink.json");
+            var request = Assert.IsAssignableFrom<AccountLinkSkillEventRequest>(convertedObj.Request);
+            Assert.Equal(request.Body.AccessToken,"testToken");
+        }
+
+        [Fact]
+        public void Can_Read_SkillEventPermissionChange()
+        {
+            var convertedObj = GetObjectFromExample<SkillRequest>("SkillEventPermissionChange.json");
+            var request = Assert.IsAssignableFrom<PermissionSkillEventRequest>(convertedObj.Request);
+            Assert.Equal(request.Body.AcceptedPermissions.First().Scope, "testScope");
+        }
+
+        [Fact]
+        public void Can_Read_NonSpecialisedSkillEvent()
+        {
+            var convertedObj = GetObjectFromExample<SkillRequest>("SkillEventEnabled.json");
+            var request = Assert.IsAssignableFrom<SkillEventRequest>(convertedObj.Request);
+        }
 
         private bool CompareObjectJson(object actual, object expected)
         {

--- a/Alexa.NET/Request/Type/AccountLinkSkillEventRequest.cs
+++ b/Alexa.NET/Request/Type/AccountLinkSkillEventRequest.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request.Type
+{
+    public class AccountLinkSkillEventRequest:Request
+    {
+        [JsonProperty("body")]
+        public AccountLinkSkillEventDetail Body { get; set; }
+    }
+
+    public class AccountLinkSkillEventDetail
+    {
+        [JsonProperty("accessToken")]
+        public string AccessToken { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/Permission.cs
+++ b/Alexa.NET/Request/Type/Permission.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request.Type
+{
+    public class Permission
+    {
+        [JsonProperty("scope")]
+        public string Scope { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/PermissionSkillEventRequest.cs
+++ b/Alexa.NET/Request/Type/PermissionSkillEventRequest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request.Type
+{
+    public class PermissionSkillEventRequest:Request
+    {
+        [JsonProperty("body")]
+        public SkillEventPermissions Body { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/RequestConverter.cs
+++ b/Alexa.NET/Request/Type/RequestConverter.cs
@@ -40,6 +40,13 @@ namespace Alexa.NET.Request.Type
                 requestType = "AudioPlayer";
             else if (requestType.StartsWith("PlaybackController"))
                 requestType = "PlaybackController";
+            else if (requestType == "AlexaSkillEvent.SkillPermissionAccepted" ||
+                     requestType == "AlexaSkillEvent.SkillPermissionChanged")
+                requestType = "PermissionSkillEvent";
+            else if (requestType == "AlexaSkillEvent.SkillAccountLinked")
+                requestType = "AccountLinkSkillEvent";
+            else if (requestType.StartsWith("AlexaSkillEvent"))
+                requestType = "AlexaSkillEvent";
 
             switch (requestType)
             {
@@ -55,6 +62,12 @@ namespace Alexa.NET.Request.Type
                     return new PlaybackControllerRequest();
                 case "System.ExceptionEncountered":
                     return new SystemExceptionRequest();
+                case "AccountLinkSkillEvent":
+                    return new AccountLinkSkillEventRequest();
+                case "PermissionSkillEvent":
+                    return new PermissionSkillEventRequest();
+                case "AlexaSkillEvent":
+                    return new SkillEventRequest();
                 default:
                     throw new ArgumentOutOfRangeException(nameof(Type), $"Unknown request type: {requestType}.");
             }

--- a/Alexa.NET/Request/Type/SkillEventPermissions.cs
+++ b/Alexa.NET/Request/Type/SkillEventPermissions.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request.Type
+{
+    public class SkillEventPermissions
+    {
+        [JsonProperty("acceptedPermissions")]
+        public Permission[] AcceptedPermissions { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/SkillEventRequest.cs
+++ b/Alexa.NET/Request/Type/SkillEventRequest.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Alexa.NET.Request.Type
+{
+    public class SkillEventRequest:Request
+    {
+    }
+}


### PR DESCRIPTION
Amazon have added a number of out of session requests that a skill can now receive for specific skill events (such as enabling the skill, account link etc.)

These changes update the request object model to honour these new request types, and tests to back it up.

Resources:
[Announcement Article](https://developer.amazon.com/blogs/alexa/post/e7a57ec4-f9e0-4efa-9052-06d320245f9b/announcing-alexa-skill-management-api-alexa-skills-kit-command-line-interface-and-events-in-alexa-skills-kit)
[Documentation on Skill Events](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/skill-events-in-alexa-skills)