### PR TITLE
Drop to NetStandard 1.4

### DIFF
--- a/Alexa.NET/Alexa.NET.csproj
+++ b/Alexa.NET/Alexa.NET.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Alexa.NET</AssemblyTitle>
     <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Tim Heuer</Authors>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.4</TargetFramework>
     <AssemblyName>Alexa.NET</AssemblyName>
     <PackageId>Alexa.NET</PackageId>
     <PackageTags>amazon;alexa;echo;dot;echo dot;skills</PackageTags>


### PR DESCRIPTION
Drop NetStandard version from 1.6 to 1.4, compilation and tests still work but it allows usage with UWP applications