### PR TITLE
Deprecate ConsentToken

### DIFF
--- a/Alexa.NET/Request/Permissions.cs
+++ b/Alexa.NET/Request/Permissions.cs
@@ -1,10 +1,11 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Alexa.NET.Request
 {
     public class Permissions
     {
-        [JsonProperty("consentToken")]
+        [JsonProperty("consentToken"),Obsolete("ConsentToken is deprecated, please use SkillRequest.Context.System.ApiAccessToken")]
         public string ConsentToken { get; set; }
     }
 }


### PR DESCRIPTION
While looking over the permissions documentation I've noticed the ConsentToken can still be sent via the request, but is deprecated in favour of the ApiAccessToken.

This change marks this change against the ConsentToken property in the SkillRequest

Reference: [Get The API Access Token](https://developer.amazon.com/docs/custom-skills/device-address-api.html#get-the-api-access-token-and-device-id)

