### PR TITLE
Add Address permissions

### DIFF
--- a/Alexa.NET/Response/RequestedPermission.cs
+++ b/Alexa.NET/Response/RequestedPermission.cs
@@ -5,5 +5,7 @@ namespace Alexa.NET.Response
     {
         public const string ReadHouseholdList  = "read::alexa:household:list";
         public const string WriteHouseholdList = "write::alexa:household:list";
+        public const string FullAddress = "read::alexa:device:all:address";
+        public const string AddressCountryAndPostalCode = "read::alexa:device:all:address:country_and_postal_code";
     }
 }


### PR DESCRIPTION
Add constants required to aid skill developers to ask for Address permissions in AskForPermissionsConsent card

Reference: [response with permission card](https://developer.amazon.com/docs/custom-skills/device-address-api.html#sample-response-with-permission-card)