### PR TITLE
Extensible request parsing

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -35,6 +35,9 @@
     <None Update="Examples\GetUtterance.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\NewIntent.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\NewVersionRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Examples/NewIntent.json
+++ b/Alexa.NET.Tests/Examples/NewIntent.json
@@ -1,0 +1,24 @@
+﻿{
+  "version": "string",
+  "context": {
+    "System": {
+      "application": {
+        "applicationId": "string"
+      },
+      "user": {
+        "userId": "string",
+        "accessToken": "string",
+        "permissions": {
+          "consentToken": "string"
+        }
+      },
+      "apiEndpoint": "https://api.amazonalexa.com"
+    }
+  },
+  "request": {
+    "type": "AlexaNet.CustomIntent",
+    "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "testProperty": true
+  }
+}

--- a/Alexa.NET.Tests/NewIntentRequest.cs
+++ b/Alexa.NET.Tests/NewIntentRequest.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Tests
+{
+    public class NewIntentRequest : Request.Type.Request
+    {
+        [JsonProperty("testProperty")]
+        public bool TestProperty { get; set; }
+    }
+}

--- a/Alexa.NET.Tests/NewIntentRequestTypeConverter.cs
+++ b/Alexa.NET.Tests/NewIntentRequestTypeConverter.cs
@@ -1,0 +1,17 @@
+﻿using Alexa.NET.Request.Type;
+
+namespace Alexa.NET.Tests
+{
+    public class NewIntentRequestTypeConverter : IRequestTypeConverter
+    {
+        public bool CanConvert(string requestType)
+        {
+            return requestType == "AlexaNet.CustomIntent";
+        }
+
+        public Request.Type.Request Convert(string requestType)
+        {
+            return new NewIntentRequest();
+        }
+    }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -244,6 +244,19 @@ namespace Alexa.NET.Tests
             Assert.Equal(ConfirmationStatus.Confirmed, expected.ConfirmationStatus);
 		}
 
+        [Fact]
+        public void Can_Handle_New_Intent()
+        {
+            if (!RequestConverter.RequestConverters.Any(c => c is NewIntentRequestTypeConverter))
+            {
+                RequestConverter.RequestConverters.Add(new NewIntentRequestTypeConverter());
+            }
+
+            var request = GetObjectFromExample<SkillRequest>("NewIntent.json");
+            Assert.IsType<NewIntentRequest>(request.Request);
+            Assert.True(((NewIntentRequest) request.Request).TestProperty);
+        }
+
         private T GetObjectFromExample<T>(string filename)
         {
             var json = File.ReadAllText(Path.Combine(ExamplesPath, filename));

--- a/Alexa.NET/Request/Type/Converters/AudioPlayerRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/AudioPlayerRequestTypeConverter.cs
@@ -1,0 +1,15 @@
+﻿namespace Alexa.NET.Request.Type
+{
+    public class AudioPlayerRequestTypeConverter : IRequestTypeConverter
+    {
+        public bool CanConvert(string requestType)
+        {
+            return requestType.StartsWith("AudioPlayer");
+        }
+
+        public Request Convert(string requestType)
+        {
+            return new AudioPlayerRequest();
+        }
+    }
+}

--- a/Alexa.NET/Request/Type/Converters/DefaultRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/DefaultRequestTypeConverter.cs
@@ -1,0 +1,26 @@
+﻿namespace Alexa.NET.Request.Type
+{
+    public class DefaultRequestTypeConverter : IRequestTypeConverter
+    {
+        public bool CanConvert(string requestType)
+        {
+            return requestType == "IntentRequest" || requestType == "LaunchRequest" || requestType == "SessionEndedRequest";
+        }
+
+        public Request Convert(string requestType)
+        {
+            switch (requestType)
+            {
+                case "IntentRequest":
+                    return new IntentRequest();
+                case "LaunchRequest":
+                    return new LaunchRequest();
+                case "SessionEndedRequest":
+                    return new SessionEndedRequest();
+                case "System.ExceptionEncountered":
+                    return new SystemExceptionRequest();
+            }
+            return null;
+        }
+    }
+}

--- a/Alexa.NET/Request/Type/Converters/PlaybackRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/PlaybackRequestTypeConverter.cs
@@ -1,0 +1,15 @@
+﻿namespace Alexa.NET.Request.Type
+{
+    public class PlaybackRequestTypeConverter : IRequestTypeConverter
+    {
+        public bool CanConvert(string requestType)
+        {
+            return requestType.StartsWith("PlaybackController");
+        }
+
+        public Request Convert(string requestType)
+        {
+            return new PlaybackControllerRequest();
+        }
+    }
+}

--- a/Alexa.NET/Request/Type/Converters/SkillEventRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/SkillEventRequestTypeConverter.cs
@@ -1,0 +1,28 @@
+﻿namespace Alexa.NET.Request.Type
+{
+    public class SkillEventRequestTypeConverter : IRequestTypeConverter
+    {
+        public bool CanConvert(string requestType)
+        {
+            return requestType == "AlexaSkillEvent.SkillPermissionAccepted" ||
+                   requestType == "AlexaSkillEvent.SkillPermissionChanged" ||
+                   requestType == "AlexaSkillEvent.SkillAccountLinked" ||
+                   requestType.StartsWith("AlexaSkillEvent");
+        }
+
+        public Request Convert(string requestType)
+        {
+            if (requestType == "AlexaSkillEvent.SkillAccountLinked")
+            {
+                return new AccountLinkSkillEventRequest();
+            }
+
+            if (requestType == "AlexaSkillEvent.SkillPermissionAccepted" || requestType == "AlexaSkillEvent.SkillPermissionChanged")
+            {
+                return new PermissionSkillEventRequest();
+            }
+
+            return new SkillEventRequest();
+        }
+    }
+}

--- a/Alexa.NET/Request/Type/Converters/TemplateEventRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/TemplateEventRequestTypeConverter.cs
@@ -1,0 +1,15 @@
+﻿namespace Alexa.NET.Request.Type
+{
+    public class TemplateEventRequestTypeConverter : IRequestTypeConverter
+    {
+        public bool CanConvert(string requestType)
+        {
+            return requestType == "Display.ElementSelected";
+        }
+
+        public Request Convert(string requestType)
+        {
+            return new DisplayElementSelectedRequest();
+        }
+    }
+}

--- a/Alexa.NET/Request/Type/IRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/IRequestTypeConverter.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Alexa.NET.Request.Type
+{
+    public interface IRequestTypeConverter
+    {
+        bool CanConvert(string requestType);
+        Request Convert(string requestType);
+    }
+}

--- a/Alexa.NET/Request/Type/RequestConverter.cs
+++ b/Alexa.NET/Request/Type/RequestConverter.cs
@@ -45,7 +45,6 @@ namespace Alexa.NET.Request.Type
 
         public Request Create(string requestType)
         {
-
             var converter = RequestConverters.FirstOrDefault(c => c.CanConvert(requestType));
             return converter?.Convert(requestType) ?? throw new ArgumentOutOfRangeException(nameof(Type), $"Unknown request type: {requestType}.");
         }


### PR DESCRIPTION
Currently Amazon are releasing changes to their request types for Alexa at a fast pace. This is causing two problems:

-  There are, at any one time, request types we can't handle
-  There are types of request only in preview, subject to change, or part of a larger piece of work that we wouldn't want to handle in Alexa.NET

These changes alter the RequestConverter internally so that the type of request generated is handled by a list of objects, each handling one or more of request types.

The idea is that developers can then add/alter the request types that the main package is missing, or handle them using the main package while awaiting confirmation of a pull request.

there is an example of expected behavior in the new Can_Handle_New_Intent test