### PR TITLE
PR to alter ShouldEndSession for Gadget API support

### DIFF
--- a/Alexa.NET/Response/Response.cs
+++ b/Alexa.NET/Response/Response.cs
@@ -14,9 +14,8 @@ namespace Alexa.NET.Response
         [JsonProperty("reprompt", NullValueHandling = NullValueHandling.Ignore)]
         public Reprompt Reprompt { get; set; }
 
-        [JsonProperty("shouldEndSession")]
-        [JsonRequired]
-        public bool ShouldEndSession { get; set; }
+        [JsonProperty("shouldEndSession", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? ShouldEndSession { get; set; } = false;
 
         [JsonProperty("directives", NullValueHandling = NullValueHandling.Ignore)]
         public IList<IDirective> Directives { get; set; } = new List<IDirective>();


### PR DESCRIPTION
Early next year the Gadget API is going to be released to the public. I'm currently working on a separate package to support this API, but obviously using Alexa.NET as the core. The issue is there's one situation in the documentation Alexa.NET does not currently allow support for.

Currently the "shouldEndSession" property in the response object is set to false or true dependent on whether or not Alexa needs to listen for a response or not. With the Gadget API there is a third option - which is that the session requires no voice, but should remain open for Gadget input (such as pressing an Echo Button).

According to the documentation - this should be handled by not rendering the shouldEndSession property at all. This PR adjusts the ShouldEndSession property from a bool to a bool? with a default value of false, and null handling to ignore the property if it's null.

This allows for existing behavior to continue correctly (implicit conversions handle that, all current tests pass). But also ensures that the objects can be used for this new purpose as well.

I'd really appreciate if this could be merged in, maybe as pre-release seeing as the Gadget API isn't public yet? That way we could be ready to support the new functionality in .NET Core when it does.

Amazon documentation regarding this situation: [Gadgets Skill API - Keeping a skill session open](https://developer.amazon.com/docs/gadget-skills/keep-echo-button-skill-session-open.html#keep-open)