### PR TITLE
Update offsetInMilliseconds to type long

### DIFF
--- a/Alexa.NET/Response/Directive/AudioItemStream.cs
+++ b/Alexa.NET/Response/Directive/AudioItemStream.cs
@@ -17,6 +17,6 @@ namespace Alexa.NET.Response.Directive
 
         [JsonRequired]
         [JsonProperty("offsetInMilliseconds")]
-        public int OffsetInMilliseconds { get; set; }
+        public long OffsetInMilliseconds { get; set; }
     }
 }

--- a/Alexa.NET/ResponseBuilder.cs
+++ b/Alexa.NET/ResponseBuilder.cs
@@ -252,12 +252,12 @@ namespace Alexa.NET
             return AudioPlayerPlay(playBehavior, url, token, 0);
         }
 
-        public static SkillResponse AudioPlayerPlay(PlayBehavior playBehavior, string url, string token, int offsetInMilliseconds)
+        public static SkillResponse AudioPlayerPlay(PlayBehavior playBehavior, string url, string token, long offsetInMilliseconds)
         {
             return AudioPlayerPlay(playBehavior, url, token, null, offsetInMilliseconds);
         }
 
-        public static SkillResponse AudioPlayerPlay(PlayBehavior playBehavior, string url, string token, string expectedPreviousToken, int offsetInMilliseconds)
+        public static SkillResponse AudioPlayerPlay(PlayBehavior playBehavior, string url, string token, string expectedPreviousToken, long offsetInMilliseconds)
         {
             var response = BuildResponse(null, true, null, null, null);
             response.Response.Directives.Add(new AudioPlayerPlayDirective()


### PR DESCRIPTION
This allows you to pass the offset straight back.

    return ResponseBuilder.AudioPlayerPlay(
         PlayBehavior.ReplaceAll,
         input.Context.AudioPlayer.Token,
         input.Context.AudioPlayer.Token,
         input.Context.AudioPlayer.OffsetInMilliseconds);