### PR TITLE
Tidier ssml

### DIFF
--- a/Alexa.NET.Tests/SsmlTests.cs
+++ b/Alexa.NET.Tests/SsmlTests.cs
@@ -1,5 +1,6 @@
 ﻿﻿using System;
-using Xunit;
+ using System.Collections.Generic;
+ using Xunit;
 using Alexa.NET.Response.Ssml;
 using System.Xml.Linq;
 
@@ -191,7 +192,44 @@ namespace Alexa.NET.Tests
 
             Assert.Equal(expected, actual);
         }
-      
+
+        [Fact]
+        public void TerseSsml_Produces_Identical_Xml()
+        {
+            const string speech1 = "Welcome to";
+            const string speech2 = "the most awesome game ever";
+            const string speech3 = "what do you want to do?";
+
+            var expected = new Speech
+            {
+                Elements = new List<ISsml>
+                {
+                    new Paragraph
+                    {
+                        Elements = new List<IParagraphSsml>
+                        {
+                            new PlainText(speech1),
+                            new Prosody
+                            {
+                                Rate = ProsodyRate.Fast,
+                                Elements = new List<ISsml> {new Sentence(speech2)}
+                            },
+                            new Sentence(speech3)
+                        }
+                    }
+                }
+            };
+
+            var actual = new Speech(
+                new Paragraph(
+                    new PlainText(speech1),
+                    new Prosody(new Sentence(speech2)){Rate=ProsodyRate.Fast},
+                    new Sentence(speech3)
+            ));
+
+            Assert.Equal(expected.ToXml(),actual.ToXml());
+        }
+
         private void CompareXml(string expected, ISsml ssml)
         {
             var actual = ssml.ToXml().ToString(SaveOptions.DisableFormatting);

--- a/Alexa.NET/Response/Ssml/Audio.cs
+++ b/Alexa.NET/Response/Ssml/Audio.cs
@@ -10,6 +10,13 @@ namespace Alexa.NET.Response.Ssml
         public string Source { get; set; }
         public List<ISsml> Elements { get; set; } = new List<ISsml>();
 
+        public Audio() { }
+
+        public Audio(params ISsml[] elements)
+        {
+            Elements = elements.ToList();
+        }
+
         public Audio(string source)
         {
             if(string.IsNullOrWhiteSpace(source))

--- a/Alexa.NET/Response/Ssml/Paragraph.cs
+++ b/Alexa.NET/Response/Ssml/Paragraph.cs
@@ -9,6 +9,13 @@ namespace Alexa.NET.Response.Ssml
     {
         public List<IParagraphSsml> Elements {get;set;} = new List<IParagraphSsml>();
 
+        public Paragraph() { }
+
+        public Paragraph(params IParagraphSsml[] elements)
+        {
+            Elements = elements.ToList();
+        }
+
         public XNode ToXml()
         {
             return new XElement("p", Elements.Select(e => e.ToXml()));

--- a/Alexa.NET/Response/Ssml/Prosody.cs
+++ b/Alexa.NET/Response/Ssml/Prosody.cs
@@ -10,6 +10,13 @@ namespace Alexa.NET.Response.Ssml
         public string Pitch { get; set; }
         public string Volume { get; set; }
 
+        public Prosody() { }
+
+        public Prosody(params ISsml[] elements)
+        {
+            Elements = elements.ToList();
+        }
+
         public List<ISsml> Elements { get; set; } = new List<ISsml>();
 
         public XNode ToXml()

--- a/Alexa.NET/Response/Ssml/Sentence.cs
+++ b/Alexa.NET/Response/Ssml/Sentence.cs
@@ -8,11 +8,15 @@ namespace Alexa.NET.Response.Ssml
     public class Sentence:IParagraphSsml
     {
         public Sentence(){}
-        public Sentence(string text){
-            Elements.Add(new PlainText(text));
+        public Sentence(string text):this(new PlainText(text)){
         }
 
-        public List<ISentenceSsml> Elements { get; set; } = new List<ISentenceSsml>();
+        public Sentence(params ISentenceSsml[] elements)
+        {
+            Elements = elements.ToList();
+        }
+
+    public List<ISentenceSsml> Elements { get; set; } = new List<ISentenceSsml>();
 
         public XNode ToXml()
         {

--- a/Alexa.NET/Response/Ssml/Speech.cs
+++ b/Alexa.NET/Response/Ssml/Speech.cs
@@ -8,7 +8,16 @@ namespace Alexa.NET.Response.Ssml
 	public class Speech
 	{
 
-		public List<ISsml> Elements { get; set; } = new List<ISsml>();
+	    public Speech()
+	    {
+	    }
+
+	    public Speech(params ISsml[] elements)
+	    {
+	        Elements = elements.ToList();
+	    }
+
+	    public List<ISsml> Elements { get; set; } = new List<ISsml>();
 
 
 		public string ToXml()


### PR DESCRIPTION
I've added an extra params constructor to all containing Ssml elements, allowing for the Elements list in each of them to be implied rather than absolute. It means the following two statements produce the same Ssml markup - but the second is so much cleaner and easier to read.

            var currentSsml = new Speech
            {
                Elements = new List<ISsml>
                {
                    new Paragraph
                    {
                        Elements = new List<IParagraphSsml>
                        {
                            new PlainText(speech1),
                            new Prosody
                            {
                                Rate = ProsodyRate.Fast,
                                Elements = new List<ISsml> {new Sentence(speech2)}
                            },
                            new Sentence(speech3)
                        }
                    }
                }
            };

            var newSsml = new Speech(
                new Paragraph(
                    new PlainText(speech1),
                    new Prosody(new Sentence(speech2)){Rate=ProsodyRate.Fast},
                    new Sentence(speech3)
            ));