### PR TITLE
Audio player update

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -122,6 +122,12 @@
     <None Update="Examples\VoicePlayerSpeakDirective.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\AudioPlayerWithMetadata.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\AudioPlayerWithoutMetadata.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Alexa.NET.Tests/Examples/AudioPlayerWithMetadata.json
+++ b/Alexa.NET.Tests/Examples/AudioPlayerWithMetadata.json
@@ -1,0 +1,30 @@
+﻿{
+  "type": "AudioPlayer.Play",
+  "playBehavior": "ENQUEUE",
+  "audioItem": {
+    "stream": {
+      "url": "https://url-of-the-stream-to-play",
+      "token": "opaque token representing this stream",
+      "expectedPreviousToken": "opaque token representing the previous stream",
+      "offsetInMilliseconds": 0
+    },
+    "metadata": {
+      "title": "title of the track to display",
+      "subtitle": "subtitle of the track to display",
+      "art": {
+        "sources": [
+          {
+            "url": "https://url-of-the-album-art-image.png"
+          }
+        ]
+      },
+      "backgroundImage": {
+        "sources": [
+          {
+            "url": "https://url-of-the-background-image.png"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/Alexa.NET.Tests/Examples/AudioPlayerWithoutMetadata.json
+++ b/Alexa.NET.Tests/Examples/AudioPlayerWithoutMetadata.json
@@ -1,0 +1,12 @@
+﻿{
+  "type": "AudioPlayer.Play",
+  "playBehavior": "ENQUEUE",
+  "audioItem": {
+    "stream": {
+      "url": "https://url-of-the-stream-to-play",
+      "token": "opaque token representing this stream",
+      "expectedPreviousToken": "opaque token representing the previous stream",
+      "offsetInMilliseconds": 0
+    }
+  }
+}

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Alexa.NET.Response;
 using Alexa.NET.Response.Directive;
@@ -75,7 +76,7 @@ namespace Alexa.NET.Tests
                     Subtitle = "Secondary Title for Sample Video"
                 }
             };
-            var actual = new VideoAppDirective{VideoItem=videoItem};
+            var actual = new VideoAppDirective { VideoItem = videoItem };
 
             Assert.True(Utility.CompareJson(actual, "VideoAppDirectiveWithMetadata.json"));
         }
@@ -98,28 +99,76 @@ namespace Alexa.NET.Tests
                 ""text"": ""sample text""
             }
         }");
-            Assert.True(CompareJson(actual,expected));
+            Assert.True(CompareJson(actual, expected));
         }
 
         [Fact]
-        public void AudioPlayerWithMetadataSerializesCorrectly()
-		{
-			var audioPlayer = Utility.ExampleFileContent<AudioPlayerPlayDirective>("AudioPlayerWithMetadata.json");
-			Assert.Equal("title of the track to display", audioPlayer.AudioItem.Metadata.Title);
-			Assert.Equal("subtitle of the track to display", audioPlayer.AudioItem.Metadata.Subtitle);
-			Assert.Single(audioPlayer.AudioItem.Metadata.Art.Sources);
-			Assert.Single(audioPlayer.AudioItem.Metadata.BackgroundImage.Sources);
-			Assert.Equal("https://url-of-the-album-art-image.png", audioPlayer.AudioItem.Metadata.Art.Sources.First().Url);
-			Assert.Equal("https://url-of-the-background-image.png", audioPlayer.AudioItem.Metadata.BackgroundImage.Sources.First().Url);
-		}
+        public void AudioPlayerGeneratesCorrectJson()
+        {
+            var directive = new AudioPlayerPlayDirective
+            {
+                PlayBehavior = PlayBehavior.Enqueue,
+                AudioItem = new AudioItem
+                {
+                    Stream = new AudioItemStream
+                    {
+                        Url = "https://url-of-the-stream-to-play",
+                        Token = "opaque token representing this stream",
+                        ExpectedPreviousToken = "opaque token representing the previous stream"
+                    }
+                }
+            };
+            Assert.True(Utility.CompareJson(directive, "AudioPlayerWithoutMetadata.json"));
+        }
+
+        [Fact]
+        public void AudioPlayerWithMetadataGeneratesCorrectJson()
+        {
+            var directive = new AudioPlayerPlayDirective
+            {
+                PlayBehavior = PlayBehavior.Enqueue,
+                AudioItem = new AudioItem
+                {
+                    Stream = new AudioItemStream
+                    {
+                        Url = "https://url-of-the-stream-to-play",
+                        Token = "opaque token representing this stream",
+                        ExpectedPreviousToken = "opaque token representing the previous stream"
+                    },
+                    Metadata = new AudioItemMetadata
+                    {
+                        Title = "title of the track to display",
+                        Subtitle = "subtitle of the track to display",
+                        Art = new AudioItemSources
+                        {
+                            Sources = new[] { new AudioItemSource("https://url-of-the-album-art-image.png") }.ToList()
+                        },
+                        BackgroundImage = new AudioItemSources { Sources = new[] { new AudioItemSource("https://url-of-the-background-image.png") }.ToList() }
+                    }
+                }
+            };
+            Assert.True(Utility.CompareJson(directive, "AudioPlayerWithMetadata.json"));
+        }
+
+        [Fact]
+        public void AudioPlayerWithMetadataDeserializesCorrectly()
+        {
+            var audioPlayer = Utility.ExampleFileContent<AudioPlayerPlayDirective>("AudioPlayerWithMetadata.json");
+            Assert.Equal("title of the track to display", audioPlayer.AudioItem.Metadata.Title);
+            Assert.Equal("subtitle of the track to display", audioPlayer.AudioItem.Metadata.Subtitle);
+            Assert.Single(audioPlayer.AudioItem.Metadata.Art.Sources);
+            Assert.Single(audioPlayer.AudioItem.Metadata.BackgroundImage.Sources);
+            Assert.Equal("https://url-of-the-album-art-image.png", audioPlayer.AudioItem.Metadata.Art.Sources.First().Url);
+            Assert.Equal("https://url-of-the-background-image.png", audioPlayer.AudioItem.Metadata.BackgroundImage.Sources.First().Url);
+        }
 
         [Fact]
         public void AudioPlayerIgnoresMetadataWhenNull()
-		{
-			var audioPlayer = Utility.ExampleFileContent<AudioPlayerPlayDirective>("AudioPlayerWithoutMetadata.json");
-			Assert.Null(audioPlayer.AudioItem.Metadata);
-			Assert.Equal("https://url-of-the-stream-to-play", audioPlayer.AudioItem.Stream.Url);
-		}
+        {
+            var audioPlayer = Utility.ExampleFileContent<AudioPlayerPlayDirective>("AudioPlayerWithoutMetadata.json");
+            Assert.Null(audioPlayer.AudioItem.Metadata);
+            Assert.Equal("https://url-of-the-stream-to-play", audioPlayer.AudioItem.Stream.Url);
+        }
 
         private bool CompareJson(object actual, JObject expected)
         {

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Alexa.NET.Response;
 using Alexa.NET.Response.Directive;
@@ -99,6 +100,26 @@ namespace Alexa.NET.Tests
         }");
             Assert.True(CompareJson(actual,expected));
         }
+
+        [Fact]
+        public void AudioPlayerWithMetadataSerializesCorrectly()
+		{
+			var audioPlayer = Utility.ExampleFileContent<AudioPlayerPlayDirective>("AudioPlayerWithMetadata.json");
+			Assert.Equal("title of the track to display", audioPlayer.AudioItem.Metadata.Title);
+			Assert.Equal("subtitle of the track to display", audioPlayer.AudioItem.Metadata.Subtitle);
+			Assert.Single(audioPlayer.AudioItem.Metadata.Art.Sources);
+			Assert.Single(audioPlayer.AudioItem.Metadata.BackgroundImage.Sources);
+			Assert.Equal("https://url-of-the-album-art-image.png", audioPlayer.AudioItem.Metadata.Art.Sources.First().Url);
+			Assert.Equal("https://url-of-the-background-image.png", audioPlayer.AudioItem.Metadata.BackgroundImage.Sources.First().Url);
+		}
+
+        [Fact]
+        public void AudioPlayerIgnoresMetadataWhenNull()
+		{
+			var audioPlayer = Utility.ExampleFileContent<AudioPlayerPlayDirective>("AudioPlayerWithoutMetadata.json");
+			Assert.Null(audioPlayer.AudioItem.Metadata);
+			Assert.Equal("https://url-of-the-stream-to-play", audioPlayer.AudioItem.Stream.Url);
+		}
 
         private bool CompareJson(object actual, JObject expected)
         {

--- a/Alexa.NET.Tests/Utility.cs
+++ b/Alexa.NET.Tests/Utility.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Alexa.NET.Tests
@@ -17,6 +18,19 @@ namespace Alexa.NET.Tests
             var expectedJObject = JObject.Parse(expected);
             Console.WriteLine(actualJObject);
             return JToken.DeepEquals(expectedJObject, actualJObject);
+        }
+
+		public static T ExampleFileContent<T>(string expectedFile)
+        {
+            using (var reader = new JsonTextReader(new StringReader(ExampleFileContent(expectedFile))))
+            {
+                return new JsonSerializer().Deserialize<T>(reader);
+            }
+        }
+
+		public static string ExampleFileContent(string expectedFile)
+        {
+            return File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
         }
     }
 }

--- a/Alexa.NET/Response/Directive/AudioItem.cs
+++ b/Alexa.NET/Response/Directive/AudioItem.cs
@@ -7,5 +7,8 @@ namespace Alexa.NET.Response.Directive
         [JsonRequired]
         [JsonProperty("stream")]
         public AudioItemStream Stream { get; set; }
+
+		[JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]
+		public AudioItemMetadata Metadata { get; set; }
     }
 }

--- a/Alexa.NET/Response/Directive/AudioItemMetadata.cs
+++ b/Alexa.NET/Response/Directive/AudioItemMetadata.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class AudioItemMetadata
+    {
+		[JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("subtitle")]
+		public string Subtitle { get; set; }
+
+		[JsonProperty("art")]
+		public AudioItemSources Art { get; set; } = new AudioItemSources();
+
+		[JsonProperty("backgroundImage")]
+		public AudioItemSources BackgroundImage { get; set; } = new AudioItemSources();
+    }
+}

--- a/Alexa.NET/Response/Directive/AudioItemSource.cs
+++ b/Alexa.NET/Response/Directive/AudioItemSource.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+	public class AudioItemSource
+	{
+		public AudioItemSource()
+		{
+		}
+
+		public AudioItemSource(string url)
+		{
+			Url = url;
+		}
+
+		[JsonProperty("url"), JsonRequired]
+		public string Url { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Directive/AudioItemSources.cs
+++ b/Alexa.NET/Response/Directive/AudioItemSources.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class AudioItemSources
+    {
+		[JsonProperty("sources")]
+		public List<AudioItemSource> Sources { get; set; } = new List<AudioItemSource>();
+    }
+}


### PR DESCRIPTION
New metadata object in the AudioPlayerPlayDirective to allow for the new [Audio Player metadata](https://developer.amazon.com/blogs/alexa/post/ccb2d51c-3eb8-4fa4-8c04-709e4294b929/enhance-your-audio-skill-visuals-for-echo-show-and-echo-spot) the Alexa team have released 