### PR TITLE
Add helper constructors to Reprompt

### DIFF
--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Alexa.NET.Response;
 using Alexa.NET.Response.Directive;
 using Alexa.NET.Response.Directive.Templates;
+using Alexa.NET.Response.Ssml;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -168,6 +169,25 @@ namespace Alexa.NET.Tests
             var audioPlayer = Utility.ExampleFileContent<AudioPlayerPlayDirective>("AudioPlayerWithoutMetadata.json");
             Assert.Null(audioPlayer.AudioItem.Metadata);
             Assert.Equal("https://url-of-the-stream-to-play", audioPlayer.AudioItem.Stream.Url);
+        }
+
+        [Fact]
+        public void RepromptStringGeneratesPlainTextOutput()
+        {
+            var result = new Reprompt("text");
+            Assert.IsType<PlainTextOutputSpeech>(result.OutputSpeech);
+            var plainText = (PlainTextOutputSpeech) result.OutputSpeech;
+            Assert.Equal("text",plainText.Text);
+        }
+
+        [Fact]
+        public void RepromptSsmlGeneratesPlainTextOutput()
+        {
+            var speech = new Speech(new PlainText("text"));
+            var result = new Reprompt(speech);
+            Assert.IsType<SsmlOutputSpeech>(result.OutputSpeech);
+            var ssmlText = (SsmlOutputSpeech)result.OutputSpeech;
+            Assert.Equal(speech.ToXml(), ssmlText.Ssml);
         }
 
         private bool CompareJson(object actual, JObject expected)

--- a/Alexa.NET/Response/Reprompt.cs
+++ b/Alexa.NET/Response/Reprompt.cs
@@ -4,6 +4,20 @@ namespace Alexa.NET.Response
 {
     public class Reprompt
     {
+        public Reprompt()
+        {
+        }
+
+        public Reprompt(string text)
+        {
+            OutputSpeech = new PlainTextOutputSpeech {Text = text};
+        }
+
+        public Reprompt(Ssml.Speech speech)
+        {
+            OutputSpeech = new SsmlOutputSpeech {Ssml = speech.ToXml()};
+        }
+
         [JsonProperty("outputSpeech", NullValueHandling=NullValueHandling.Ignore)]
         public IOutputSpeech OutputSpeech { get; set; }
     }


### PR DESCRIPTION
Currently to add a reprompt to an ask response you have to generate a full speech object:

```csharp
var plain = new Reprompt{OutputSpeech = new PlainTextOutputSpeech{Text=Options}}
...
var speech = new Speech(new PlainText("text"));
var ssml = new Reprompt{OutputSpeech = new SsmlOutputSpeech{Ssml = speech.ToXml()}}
```

this PR adds helper constructors to make this cleaner, but has a default constructor to ensure it's not a breaking change.

__plain text:__
```csharp
var plain = new Reprompt("plain text")
```

__ssml:__
```csharp
var speech = new Speech(new PlainText("text"));
var ssml = new Reprompt(speech)
```