### PR TITLE
Beta - Can fulfill intent request

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -17,6 +17,12 @@
     <None Remove="Examples\AskForPermissionConsent.json" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="Examples\CanFulfillIntentRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\CanFulfillResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\DialogConfirmIntent.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Examples/CanFulfillIntentRequest.json
+++ b/Alexa.NET.Tests/Examples/CanFulfillIntentRequest.json
@@ -1,0 +1,35 @@
+﻿ {
+    "version": "1.0",
+    "session": {
+      "new": false,
+      "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      },
+      "attributes": {
+        "supportedHoroscopePeriods": {
+          "daily": true,
+          "weekly": false,
+          "monthly": false
+        }
+      },
+      "user": {
+        "userId": "amzn1.account.AM3B00000000000000000000000"
+      }
+    },
+  "request": {
+    "type": "CanFulfillIntentRequest",
+    "dialogState": "IN_PROGRESS",
+    "requestId": " amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "PlaySound",
+      "slots": {
+        "Sound": {
+          "name": "Sound",
+          "value": "crickets"
+        }
+      }
+    }
+  }
+  }

--- a/Alexa.NET.Tests/Examples/CanFulfillResponse.json
+++ b/Alexa.NET.Tests/Examples/CanFulfillResponse.json
@@ -1,0 +1,9 @@
+﻿{
+  "canFulfill": "YES",
+  "slots": {
+    "slotName": {
+      "canUnderstand": "YES",
+      "canFulfill": "NO"
+    }
+  }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -13,6 +13,7 @@ namespace Alexa.NET.Tests
     {
         private const string ExamplesPath = "Examples";
         private const string IntentRequestFile = "IntentRequest.json";
+        private const string CanFulfillIntentRequestFile = "CanFulfillIntentRequest.json";
 
         [Fact]
         public void Can_read_IntentRequest_example()
@@ -21,6 +22,15 @@ namespace Alexa.NET.Tests
 
             Assert.NotNull(convertedObj);
             Assert.Equal(typeof(IntentRequest), convertedObj.GetRequestType());
+        }
+
+        [Fact]
+        public void Can_read_CanFulfillIntentRequest_example()
+        {
+            var convertedObj = GetObjectFromExample<SkillRequest>(CanFulfillIntentRequestFile);
+
+            Assert.NotNull(convertedObj);
+            Assert.Equal(typeof(CanFulfillIntentRequest), convertedObj.GetRequestType());
         }
 
         [Fact]

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -190,6 +190,18 @@ namespace Alexa.NET.Tests
             Assert.Equal(speech.ToXml(), ssmlText.Ssml);
         }
 
+        [Fact]
+        public void CanFulfillResponse()
+        {
+            var fulfillment = new CanFulfillIntent {CanFulfill = CanFulfill.YES};
+            fulfillment.Slots.Add("slotName", new CanfulfillSlot
+            {
+                CanUnderstand = CanUnderstand.YES,
+                CanFulfill = SlotCanFulfill.NO
+            });
+            Assert.True(Utility.CompareJson(fulfillment, "CanFulfillResponse.json"));
+        }
+
         private bool CompareJson(object actual, JObject expected)
         {
             var actualJObject = JObject.FromObject(actual);

--- a/Alexa.NET.Tests/Utility.cs
+++ b/Alexa.NET.Tests/Utility.cs
@@ -20,7 +20,7 @@ namespace Alexa.NET.Tests
             return JToken.DeepEquals(expectedJObject, actualJObject);
         }
 
-		public static T ExampleFileContent<T>(string expectedFile)
+        public static T ExampleFileContent<T>(string expectedFile)
         {
             using (var reader = new JsonTextReader(new StringReader(ExampleFileContent(expectedFile))))
             {

--- a/Alexa.NET/Request/Type/CanFulfillIntentRequest.cs
+++ b/Alexa.NET/Request/Type/CanFulfillIntentRequest.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request.Type
+{
+    public class CanFulfillIntentRequest:Request
+    {
+        [JsonProperty("dialogState")]
+        public string DialogState { get; set; }
+
+        [JsonProperty("intent")]
+        public Intent Intent { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/Converters/DefaultRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/DefaultRequestTypeConverter.cs
@@ -4,13 +4,19 @@
     {
         public bool CanConvert(string requestType)
         {
-            return requestType == "IntentRequest" || requestType == "LaunchRequest" || requestType == "SessionEndedRequest";
+            return requestType == "IntentRequest" || 
+                   requestType == "LaunchRequest" || 
+                   requestType == "SessionEndedRequest" ||
+                   requestType == "System.ExceptionEncountered" ||
+                   requestType == "CanFulfillIntentRequest";
         }
 
         public Request Convert(string requestType)
         {
             switch (requestType)
             {
+                case "CanFulfillIntentRequest":
+                    return new CanFulfillIntentRequest();
                 case "IntentRequest":
                     return new IntentRequest();
                 case "LaunchRequest":

--- a/Alexa.NET/Response/CanFulfill.cs
+++ b/Alexa.NET/Response/CanFulfill.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Alexa.NET.Response
+{
+    public enum CanFulfill
+    {
+        YES,
+        MAYBE,
+        NO
+    }
+}

--- a/Alexa.NET/Response/CanFulfillIntent.cs
+++ b/Alexa.NET/Response/CanFulfillIntent.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+
+namespace Alexa.NET.Response
+{
+    public class CanFulfillIntent
+    {
+        [JsonProperty("canFulfill"),JsonConverter(typeof(StringEnumConverter))]
+        public CanFulfill CanFulfill { get; set; }
+
+        [JsonProperty("slots")]
+        public Dictionary<string,CanfulfillSlot> Slots { get; set; } = new Dictionary<string, CanfulfillSlot>();
+    }
+}

--- a/Alexa.NET/Response/CanUnderstand.cs
+++ b/Alexa.NET/Response/CanUnderstand.cs
@@ -1,0 +1,9 @@
+﻿namespace Alexa.NET.Response
+{
+    public enum CanUnderstand
+    {
+        YES,
+        MAYBE,
+        NO
+    }
+}

--- a/Alexa.NET/Response/CanfulfillSlot.cs
+++ b/Alexa.NET/Response/CanfulfillSlot.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alexa.NET.Response
+{
+    public class CanfulfillSlot
+    {
+        [JsonProperty("canUnderstand"),JsonConverter(typeof(StringEnumConverter))]
+        public CanUnderstand CanUnderstand { get; set; }
+
+        [JsonProperty("canFulfill"),JsonConverter(typeof(StringEnumConverter))]
+        public SlotCanFulfill CanFulfill { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Response.cs
+++ b/Alexa.NET/Response/Response.cs
@@ -5,6 +5,9 @@ namespace Alexa.NET.Response
 {
     public class ResponseBody
     {
+        [JsonProperty("canFulfillIntent",NullValueHandling = NullValueHandling.Ignore)]
+        public CanFulfillIntent CanFulfillIntent { get; set; }
+
         [JsonProperty("outputSpeech", NullValueHandling = NullValueHandling.Ignore)]
         public IOutputSpeech OutputSpeech { get; set; }
 

--- a/Alexa.NET/Response/SlotCanFulfill.cs
+++ b/Alexa.NET/Response/SlotCanFulfill.cs
@@ -1,0 +1,8 @@
+﻿namespace Alexa.NET.Response
+{
+    public enum SlotCanFulfill
+    {
+        YES,
+        NO
+    }
+}


### PR DESCRIPTION
Amazon have launched a new public preview, allowing skills to be interrogated about requests they can handle, even if the skill isn't mentioned by name. This PR adds that functionality to Alexa.NET - Details are here:

https://developer.amazon.com/docs/custom-skills/name-free-interaction.html
https://developer.amazon.com/blogs/alexa/post/352e9834-0a98-4868-8d94-c2746b794ce9/improve-alexa-skill-discovery-and-name-free-use-of-your-skill-with-canfulfillintentrequest-beta

This is a huge benefit and should be implemented to improve the pick up of skills, but it's a public preview and affects the standard response, so I believe putting this in a pre-release is going to be most appropriate right now.