### PR TITLE
Update to Hint Directive

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -26,6 +26,9 @@
     <None Update="Examples\DisplayRenderTemplateDirective.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\HintDirective.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\IntentRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Examples/HintDirective.json
+++ b/Alexa.NET.Tests/Examples/HintDirective.json
@@ -1,0 +1,7 @@
+{
+  "type": "Hint",
+  "hint": {
+    "type": "PlainText",
+    "text": "test hint"
+  }
+}

--- a/Alexa.NET.Tests/RenderTemplateTests.cs
+++ b/Alexa.NET.Tests/RenderTemplateTests.cs
@@ -302,6 +302,13 @@ namespace Alexa.NET.Tests
             Assert.True(CompareJson(actual, "TemplateImage.json"));
         }
 
+        [Fact]
+        public void HintCreatesCorrectJson()
+        {
+            var hint = new HintDirective("test hint");
+            Assert.True(CompareJson(hint, "HintDirective.json"));
+        }
+
         private bool CompareJson(object actual, string expectedFile)
         {
 

--- a/Alexa.NET/Response/Directive/Hint.cs
+++ b/Alexa.NET/Response/Directive/Hint.cs
@@ -1,13 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Alexa.NET.Response.Directive.Templates;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Alexa.NET.Response.Directive
 {
     public class Hint
     {
+        public Hint()
+        {
+        }
+
+        public Hint(string hintText, string textType = TextType.Plain)
+        {
+            Text = hintText;
+            Type = textType;
+        }
+
         [JsonProperty("type")]
         public string Type { get; set; }
         

--- a/Alexa.NET/Response/Directive/HintDirective.cs
+++ b/Alexa.NET/Response/Directive/HintDirective.cs
@@ -1,13 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Alexa.NET.Response.Directive.Templates;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Alexa.NET.Response.Directive
 {
     public class HintDirective:IDirective
     {
+        public HintDirective()
+        {
+        }
+
+        public HintDirective(string hintText, string textType = TextType.Plain)
+        {
+            Hint = new Hint(hintText, textType);
+        }
+
         [JsonProperty("type")]
         public string Type => "Hint";
         


### PR DESCRIPTION
Hint directives are often just helpful text added to a display template, but requires the object structure to be created.

These changes add helper constructors to the hint and hint directive objects to make this less verbose.

Added a test to ensure they still produce the correct json