### PR TITLE
Add Dynamic Entity support

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -23,6 +23,9 @@
     <None Update="Examples\BuiltInIntentRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\DialogDynamicEntity.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\DisplayRenderTemplateDirective.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/DialogDirectiveTests.cs
+++ b/Alexa.NET.Tests/DialogDirectiveTests.cs
@@ -12,7 +12,7 @@ namespace Alexa.NET.Tests
         [Fact]
         public void Create_Valid_DialogDelegateDirective()
         {
-            var actual = new DialogDelegate{UpdatedIntent=GetUpdatedIntent()};
+            var actual = new DialogDelegate { UpdatedIntent = GetUpdatedIntent() };
 
             Assert.True(Utility.CompareJson(actual, "DialogDelegate.json"));
         }
@@ -22,16 +22,16 @@ namespace Alexa.NET.Tests
         {
             var actual = new DialogElicitSlot("ZodiacSign") { UpdatedIntent = GetUpdatedIntent() };
 
-			Assert.True(Utility.CompareJson(actual, "DialogElicitSlot.json"));
+            Assert.True(Utility.CompareJson(actual, "DialogElicitSlot.json"));
         }
 
-		[Fact]
-		public void Create_Valid_DialogConfirmSlotDirective()
-		{
-			var actual = new DialogConfirmSlot("Date") { UpdatedIntent = GetUpdatedIntent() };
+        [Fact]
+        public void Create_Valid_DialogConfirmSlotDirective()
+        {
+            var actual = new DialogConfirmSlot("Date") { UpdatedIntent = GetUpdatedIntent() };
 
-			Assert.True(Utility.CompareJson(actual, "DialogConfirmSlot.json"));
-		}
+            Assert.True(Utility.CompareJson(actual, "DialogConfirmSlot.json"));
+        }
 
         [Fact]
         public void Create_Valid_DialogConfirmIntentDirective()
@@ -42,17 +42,50 @@ namespace Alexa.NET.Tests
             Assert.True(Utility.CompareJson(actual, "DialogConfirmIntent.json"));
         }
 
+        [Fact]
+        public void Create_Valid_DialogDynamicEntityDirective()
+        {
+            var actual = new DialogUpdateDynamicEntities { UpdateBehavior = UpdateBehavior.Replace };
+            var airportSlotType = new SlotType
+            {
+                Name = "AirportSlotType",
+                Values = new[]
+                {
+                    new SlotTypeValue
+                    {
+                        Id = "BOS",
+                        Name = new SlotTypeValueName
+                        {
+                            Value = "Logan International Airport",
+                            Synonyms = new[] {"Boston Logan"}
+                        }
+                    },
+                    new SlotTypeValue
+                    {
+                        Id = "LGA",
+                        Name = new SlotTypeValueName
+                        {
+                            Value = "LaGuardia Airport",
+                            Synonyms = new[] {"New York"}
+                        }
+                    }
+                }
+            };
+            actual.Types.Add(airportSlotType);
+            Assert.True(Utility.CompareJson(actual, "DialogDynamicEntity.json"));
+        }
+
         private Intent GetUpdatedIntent()
         {
-			return new Intent
-			{
-				Name = "GetZodiacHoroscopeIntent",
-				ConfirmationStatus = ConfirmationStatus.None,
-				Slots = new System.Collections.Generic.Dictionary<string, Slot>{
-					{"ZodiacSign",new Slot{Name="ZodiacSign",Value="virgo"}},
-						{"Date",new Slot{Name="Date",Value="2015-11-25",ConfirmationStatus=ConfirmationStatus.Confirmed}}
-				}
-			};
+            return new Intent
+            {
+                Name = "GetZodiacHoroscopeIntent",
+                ConfirmationStatus = ConfirmationStatus.None,
+                Slots = new System.Collections.Generic.Dictionary<string, Slot>{
+                    {"ZodiacSign",new Slot{Name="ZodiacSign",Value="virgo"}},
+                        {"Date",new Slot{Name="Date",Value="2015-11-25",ConfirmationStatus=ConfirmationStatus.Confirmed}}
+                }
+            };
         }
     }
 }

--- a/Alexa.NET.Tests/Examples/DialogDynamicEntity.json
+++ b/Alexa.NET.Tests/Examples/DialogDynamicEntity.json
@@ -1,0 +1,29 @@
+﻿{
+  "type": "Dialog.UpdateDynamicEntities",
+  "updateBehavior": "REPLACE",
+  "types": [
+    {
+      "name": "AirportSlotType",
+      "values": [
+        {
+          "id": "BOS",
+          "name": {
+            "value": "Logan International Airport",
+            "synonyms": [
+              "Boston Logan"
+            ]
+          }
+        },
+        {
+          "id": "LGA",
+          "name": {
+            "value": "LaGuardia Airport",
+            "synonyms": [
+              "New York"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Alexa.NET/Response/Directive/DialogUpdateDynamicEntities.cs
+++ b/Alexa.NET/Response/Directive/DialogUpdateDynamicEntities.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class DialogUpdateDynamicEntities : IDirective
+    {
+        [JsonProperty("type")]
+        public string Type => "Dialog.UpdateDynamicEntities";
+
+        [JsonProperty("updateBehavior"), JsonConverter(typeof(StringEnumConverter))]
+        public UpdateBehavior UpdateBehavior { get; set; }
+
+        [JsonProperty("types")]
+        public List<SlotType> Types { get; set; } = new List<SlotType>();
+    }
+}

--- a/Alexa.NET/Response/Directive/SlotType.cs
+++ b/Alexa.NET/Response/Directive/SlotType.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class SlotType
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("values")]
+        public SlotTypeValue[] Values { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Directive/SlotTypeValue.cs
+++ b/Alexa.NET/Response/Directive/SlotTypeValue.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class SlotTypeValue
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public SlotTypeValueName Name { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Directive/SlotTypeValueName.cs
+++ b/Alexa.NET/Response/Directive/SlotTypeValueName.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class SlotTypeValueName
+    {
+        [JsonProperty("value")]
+        public string Value { get; set; }
+
+        [JsonProperty("synonyms", NullValueHandling = NullValueHandling.Ignore)]
+        public string[] Synonyms { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Directive/UpdateBehavior.cs
+++ b/Alexa.NET/Response/Directive/UpdateBehavior.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace Alexa.NET.Response.Directive
+{
+    public enum UpdateBehavior
+    {
+        [EnumMember(Value = "REPLACE")]
+        Replace,
+        [EnumMember(Value = "CLEAR")]
+        Clear
+    }
+}


### PR DESCRIPTION
Skill developers can now update their slot types dynamically without re-submitting their skill definitions for re-certification.

This PR covers the new directive, the new types required and a test to ensure it's being serialized properly.

__Resources__
[Blog Entry](https://developer.amazon.com/blogs/alexa/post/db4c0ed5-5a05-4037-a3a7-3fe5c29dcb65/use-dynamic-entities-to-create-personalized-voice-experiences)
[Technical Docs](https://developer.amazon.com/docs/custom-skills/use-dynamic-entities-for-customized-interactions.html)

Because the team normally know what they're doing - the slot type definitions match those used by the SMAPI, so I've taken the slot information from Alexa.NET.Management and they pass the test directive in the technical docs (not referenced it directly, .Management is really too big to reference these days for such a small overlap)