### PR TITLE
Add session ended error object

### DIFF
--- a/Alexa.NET.Tests/Examples/SessionEndedRequest.json
+++ b/Alexa.NET.Tests/Examples/SessionEndedRequest.json
@@ -21,6 +21,10 @@
         "type": "SessionEndedRequest",
         "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
         "timestamp": "2015-05-13T12:34:56Z",
-        "reason": "USER_INITIATED"
+      "reason": "USER_INITIATED",
+      "error": {
+        "type": "INVALID_RESPONSE",
+        "message": "test message"
+      }
     }
 }

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -80,7 +80,9 @@ namespace Alexa.NET.Tests
             var convertedObj = GetObjectFromExample<SkillRequest>("SessionEndedRequest.json");
 
             Assert.NotNull(convertedObj);
-            Assert.Equal(typeof(SessionEndedRequest), convertedObj.GetRequestType());
+            var sessionEndedRequest = Assert.IsType<SessionEndedRequest>(convertedObj.Request);
+            Assert.Equal(ErrorType.InvalidResponse,sessionEndedRequest.Error.Type);
+            Assert.Equal("test message", sessionEndedRequest.Error.Message);
         }
 
         [Fact]

--- a/Alexa.NET/Request/Type/SessionEndedRequest.cs
+++ b/Alexa.NET/Request/Type/SessionEndedRequest.cs
@@ -8,5 +8,8 @@ namespace Alexa.NET.Request.Type
         [JsonProperty("reason")]
         [JsonConverter(typeof(StringEnumConverter))]
         public Reason Reason { get; set; }
+
+        [JsonProperty("error",NullValueHandling=NullValueHandling.Ignore)]
+        public Error Error { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #132 - appears the Error object from SystemExceptionRequest is now inside SessionEndedRequest instead

Added object to request type and updated test & json

Link to documentation: https://developer.amazon.com/docs/custom-skills/request-types-reference.html#sessionendedrequest