### PR TITLE
Add PlayBehavior to OutputSpeech

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -68,6 +68,9 @@
     <None Update="Examples\PlainTextOutputSpeech.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\PlainTextOutputSpeechWithPlayBehavior.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\PrintImageConnection.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -108,6 +111,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Examples\SsmlOutputSpeech.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\SsmlOutputSpeechWithPlayBehavior.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Examples\StandardCard.json">

--- a/Alexa.NET.Tests/Examples/PlainTextOutputSpeechWithPlayBehavior.json
+++ b/Alexa.NET.Tests/Examples/PlainTextOutputSpeechWithPlayBehavior.json
@@ -1,0 +1,5 @@
+﻿{
+  "type": "PlainText",
+  "text": "text content",
+  "playBehavior": "REPLACE_ALL"
+}

--- a/Alexa.NET.Tests/Examples/SsmlOutputSpeechWithPlayBehavior.json
+++ b/Alexa.NET.Tests/Examples/SsmlOutputSpeechWithPlayBehavior.json
@@ -1,0 +1,5 @@
+﻿{
+  "type": "SSML",
+  "ssml": "ssml content",
+  "playBehavior": "REPLACE_ENQUEUED"
+}

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -259,6 +259,21 @@ namespace Alexa.NET.Tests
 
             Assert.Equal("PlainText", outputSpeech.Type);
             Assert.Equal("text content", outputSpeech.Text);
+            Assert.Equal(null, outputSpeech.PlayBehavior);
+        }
+
+        [Fact]
+        public void DeserializesExamplePlainTextOutputSpeechWithPlayBehaviorJson()
+        {
+            var deserialized = Utility.ExampleFileContent<IOutputSpeech>("PlainTextOutputSpeechWithPlayBehavior.json");
+
+            Assert.Equal(typeof(PlainTextOutputSpeech), deserialized.GetType());
+
+            var outputSpeech = (PlainTextOutputSpeech)deserialized;
+
+            Assert.Equal("PlainText", outputSpeech.Type);
+            Assert.Equal("text content", outputSpeech.Text);
+            Assert.Equal(PlayBehavior.ReplaceAll, outputSpeech.PlayBehavior);
         }
 
         [Fact]
@@ -272,6 +287,20 @@ namespace Alexa.NET.Tests
 
             Assert.Equal("SSML", outputSpeech.Type);
             Assert.Equal("ssml content", outputSpeech.Ssml);
+        }
+
+        [Fact]
+        public void DeserializesExampleSsmlOutputSpeechWithPlayBehaviorJson()
+        {
+            var deserialized = Utility.ExampleFileContent<IOutputSpeech>("SsmlOutputSpeechWithPlayBehavior.json");
+
+            Assert.Equal(typeof(SsmlOutputSpeech), deserialized.GetType());
+
+            var outputSpeech = (SsmlOutputSpeech)deserialized;
+
+            Assert.Equal("SSML", outputSpeech.Type);
+            Assert.Equal("ssml content", outputSpeech.Ssml);
+            Assert.Equal(PlayBehavior.ReplaceEnqueued, outputSpeech.PlayBehavior);
         }
 
         [Fact]

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -249,6 +249,24 @@ namespace Alexa.NET.Tests
         }
 
         [Fact]
+        public void SerializesPlainTextOutputSpeechToJson()
+        {
+            var plainTextOutputSpeech = new PlainTextOutputSpeech { Text = "text content" };
+            var json = JsonConvert.SerializeObject(plainTextOutputSpeech, Formatting.Indented, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            const string example = "PlainTextOutputSpeech.json";
+            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
+
+            workingJson = Regex.Replace(workingJson, @"\s", "");
+            json = Regex.Replace(json, @"\s", "");
+
+            Assert.Equal(workingJson, json);
+        }
+
+        [Fact]
         public void DeserializesExamplePlainTextOutputSpeechJson()
         {
             var deserialized = Utility.ExampleFileContent<IOutputSpeech>("PlainTextOutputSpeech.json");
@@ -260,6 +278,24 @@ namespace Alexa.NET.Tests
             Assert.Equal("PlainText", outputSpeech.Type);
             Assert.Equal("text content", outputSpeech.Text);
             Assert.Equal(null, outputSpeech.PlayBehavior);
+        }
+
+        [Fact]
+        public void SerializesPlainTextOutputSpeechWithPlayBehaviorToJson()
+        {
+            var plainTextOutputSpeech = new PlainTextOutputSpeech { Text = "text content", PlayBehavior = PlayBehavior.ReplaceAll };
+            var json = JsonConvert.SerializeObject(plainTextOutputSpeech, Formatting.Indented, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            const string example = "PlainTextOutputSpeechWithPlayBehavior.json";
+            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
+
+            workingJson = Regex.Replace(workingJson, @"\s", "");
+            json = Regex.Replace(json, @"\s", "");
+
+            Assert.Equal(workingJson, json);
         }
 
         [Fact]
@@ -277,6 +313,24 @@ namespace Alexa.NET.Tests
         }
 
         [Fact]
+        public void SerializesSsmlOutputSpeechToJson()
+        {
+            var ssmlOutputSpeech = new SsmlOutputSpeech { Ssml = "ssml content" };
+            var json = JsonConvert.SerializeObject(ssmlOutputSpeech, Formatting.Indented, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            const string example = "SsmlOutputSpeech.json";
+            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
+
+            workingJson = Regex.Replace(workingJson, @"\s", "");
+            json = Regex.Replace(json, @"\s", "");
+
+            Assert.Equal(workingJson, json);
+        }
+
+        [Fact]
         public void DeserializesExampleSsmlOutputSpeechJson()
         {
             var deserialized = Utility.ExampleFileContent<IOutputSpeech>("SsmlOutputSpeech.json");
@@ -287,6 +341,24 @@ namespace Alexa.NET.Tests
 
             Assert.Equal("SSML", outputSpeech.Type);
             Assert.Equal("ssml content", outputSpeech.Ssml);
+        }
+
+        [Fact]
+        public void SerializesSsmlOutputSpeechWithPlayBehaviorToJson()
+        {
+            var ssmlOutputSpeech = new SsmlOutputSpeech { Ssml = "ssml content", PlayBehavior = PlayBehavior.ReplaceEnqueued };
+            var json = JsonConvert.SerializeObject(ssmlOutputSpeech, Formatting.Indented, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            const string example = "SsmlOutputSpeechWithPlayBehavior.json";
+            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
+
+            workingJson = Regex.Replace(workingJson, @"\s", "");
+            json = Regex.Replace(json, @"\s", "");
+
+            Assert.Equal(workingJson, json);
         }
 
         [Fact]

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -54,18 +54,7 @@ namespace Alexa.NET.Tests
                 }
             };
 
-            var json = JsonConvert.SerializeObject(skillResponse, Formatting.Indented, new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            });
-
-            const string example = "Response.json";
-            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
-
-            workingJson = Regex.Replace(workingJson, @"\s", "");
-            json = Regex.Replace(json, @"\s", "");
-
-            Assert.Equal(workingJson, json);
+            Assert.True(Utility.CompareJson(skillResponse, "Response.json"));
         }
 
         [Fact]
@@ -252,18 +241,7 @@ namespace Alexa.NET.Tests
         public void SerializesPlainTextOutputSpeechToJson()
         {
             var plainTextOutputSpeech = new PlainTextOutputSpeech { Text = "text content" };
-            var json = JsonConvert.SerializeObject(plainTextOutputSpeech, Formatting.Indented, new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            });
-
-            const string example = "PlainTextOutputSpeech.json";
-            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
-
-            workingJson = Regex.Replace(workingJson, @"\s", "");
-            json = Regex.Replace(json, @"\s", "");
-
-            Assert.Equal(workingJson, json);
+            Assert.True(Utility.CompareJson(plainTextOutputSpeech, "PlainTextOutputSpeech.json"));
         }
 
         [Fact]
@@ -284,18 +262,7 @@ namespace Alexa.NET.Tests
         public void SerializesPlainTextOutputSpeechWithPlayBehaviorToJson()
         {
             var plainTextOutputSpeech = new PlainTextOutputSpeech { Text = "text content", PlayBehavior = PlayBehavior.ReplaceAll };
-            var json = JsonConvert.SerializeObject(plainTextOutputSpeech, Formatting.Indented, new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            });
-
-            const string example = "PlainTextOutputSpeechWithPlayBehavior.json";
-            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
-
-            workingJson = Regex.Replace(workingJson, @"\s", "");
-            json = Regex.Replace(json, @"\s", "");
-
-            Assert.Equal(workingJson, json);
+            Assert.True(Utility.CompareJson(plainTextOutputSpeech, "PlainTextOutputSpeechWithPlayBehavior.json"));
         }
 
         [Fact]
@@ -316,18 +283,7 @@ namespace Alexa.NET.Tests
         public void SerializesSsmlOutputSpeechToJson()
         {
             var ssmlOutputSpeech = new SsmlOutputSpeech { Ssml = "ssml content" };
-            var json = JsonConvert.SerializeObject(ssmlOutputSpeech, Formatting.Indented, new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            });
-
-            const string example = "SsmlOutputSpeech.json";
-            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
-
-            workingJson = Regex.Replace(workingJson, @"\s", "");
-            json = Regex.Replace(json, @"\s", "");
-
-            Assert.Equal(workingJson, json);
+            Assert.True(Utility.CompareJson(ssmlOutputSpeech, "SsmlOutputSpeech.json"));
         }
 
         [Fact]
@@ -348,18 +304,7 @@ namespace Alexa.NET.Tests
         public void SerializesSsmlOutputSpeechWithPlayBehaviorToJson()
         {
             var ssmlOutputSpeech = new SsmlOutputSpeech { Ssml = "ssml content", PlayBehavior = PlayBehavior.ReplaceEnqueued };
-            var json = JsonConvert.SerializeObject(ssmlOutputSpeech, Formatting.Indented, new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            });
-
-            const string example = "SsmlOutputSpeechWithPlayBehavior.json";
-            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
-
-            workingJson = Regex.Replace(workingJson, @"\s", "");
-            json = Regex.Replace(json, @"\s", "");
-
-            Assert.Equal(workingJson, json);
+            Assert.True(Utility.CompareJson(ssmlOutputSpeech, "SsmlOutputSpeechWithPlayBehavior.json"));
         }
 
         [Fact]

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -341,6 +341,7 @@ namespace Alexa.NET.Tests
 
             Assert.Equal("SSML", outputSpeech.Type);
             Assert.Equal("ssml content", outputSpeech.Ssml);
+            Assert.Equal(null, outputSpeech.PlayBehavior);
         }
 
         [Fact]

--- a/Alexa.NET/Response/IOutputSpeech.cs
+++ b/Alexa.NET/Response/IOutputSpeech.cs
@@ -1,4 +1,5 @@
 using Alexa.NET.Response.Converters;
+using Alexa.NET.Response.Directive;
 using Newtonsoft.Json;
 
 namespace Alexa.NET.Response
@@ -6,5 +7,6 @@ namespace Alexa.NET.Response
     [JsonConverter(typeof(OutputSpeechConverter))]
     public interface IOutputSpeech : IResponse
     {
+        PlayBehavior? PlayBehavior { get; set; }
     }
 }

--- a/Alexa.NET/Response/PlainTextOutputSpeech.cs
+++ b/Alexa.NET/Response/PlainTextOutputSpeech.cs
@@ -1,4 +1,6 @@
+using Alexa.NET.Response.Directive;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Alexa.NET.Response
 {
@@ -14,5 +16,9 @@ namespace Alexa.NET.Response
         [JsonRequired]
         [JsonProperty("text")]
         public string Text { get; set; }
+
+        [JsonProperty("playBehavior", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PlayBehavior? PlayBehavior { get; set; }
     }
 }

--- a/Alexa.NET/Response/SsmlOutputSpeech.cs
+++ b/Alexa.NET/Response/SsmlOutputSpeech.cs
@@ -1,4 +1,6 @@
+using Alexa.NET.Response.Directive;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Alexa.NET.Response
 {
@@ -14,5 +16,9 @@ namespace Alexa.NET.Response
         [JsonRequired]
         [JsonProperty("ssml")]
         public string Ssml { get; set; }
+
+        [JsonProperty("playBehavior", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PlayBehavior PlayBehavior { get; set; } = PlayBehavior.Enqueue;
     }
 }

--- a/Alexa.NET/Response/SsmlOutputSpeech.cs
+++ b/Alexa.NET/Response/SsmlOutputSpeech.cs
@@ -19,6 +19,6 @@ namespace Alexa.NET.Response
 
         [JsonProperty("playBehavior", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(StringEnumConverter))]
-        public PlayBehavior PlayBehavior { get; set; } = PlayBehavior.Enqueue;
+        public PlayBehavior? PlayBehavior { get; set; }
     }
 }


### PR DESCRIPTION
According to [the document](https://developer.amazon.com/docs/custom-skills/request-and-response-json-reference.html) outputSpeech can contain the playBehavior property. I have added corresponding property to the SsmlOutputSpeech class.