### PR TITLE
Add SkillEnabled and SkillDisabled Event

### DIFF
--- a/Alexa.NET.Tests/Examples/SkillEventPermissionChange.json
+++ b/Alexa.NET.Tests/Examples/SkillEventPermissionChange.json
@@ -15,16 +15,18 @@
       "apiEndpoint": "https://api.amazonalexa.com"
     }
   },
-	"request": {
-		"type": "AlexaSkillEvent.SkillPermissionAccepted",
-		"requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
-		"timestamp": "2015-05-13T12:34:56Z",
-		"body": {
-			"acceptedPermissions": [
-				{
-					"scope": "testScope"
-				}
-			]
-		}
-	}
+  "request": {
+    "type": "AlexaSkillEvent.SkillPermissionAccepted",
+    "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "eventCreationTime": "2015-05-13T12:34:56Z",
+    "eventPublishingTime": "2015-05-13T12:34:56Z",
+    "body": {
+      "acceptedPermissions": [
+        {
+          "scope": "testScope"
+        }
+      ]
+    }
+  }
 }

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -196,6 +196,8 @@ namespace Alexa.NET.Tests
             var convertedObj = GetObjectFromExample<SkillRequest>("SkillEventPermissionChange.json");
             var request = Assert.IsAssignableFrom<PermissionSkillEventRequest>(convertedObj.Request);
             Assert.Equal(request.Body.AcceptedPermissions.First().Scope, "testScope");
+            Assert.True(request.EventCreationTime.HasValue);
+            Assert.True(request.EventPublishingTime.HasValue);
         }
 
         [Fact]

--- a/Alexa.NET/Request/Type/AccountLinkSkillEventDetail.cs
+++ b/Alexa.NET/Request/Type/AccountLinkSkillEventDetail.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request.Type
+{
+    public class AccountLinkSkillEventDetail
+    {
+        [JsonProperty("accessToken")]
+        public string AccessToken { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/AccountLinkSkillEventRequest.cs
+++ b/Alexa.NET/Request/Type/AccountLinkSkillEventRequest.cs
@@ -5,15 +5,9 @@ using Newtonsoft.Json;
 
 namespace Alexa.NET.Request.Type
 {
-    public class AccountLinkSkillEventRequest:Request
+    public class AccountLinkSkillEventRequest:SkillEventRequest
     {
         [JsonProperty("body")]
         public AccountLinkSkillEventDetail Body { get; set; }
-    }
-
-    public class AccountLinkSkillEventDetail
-    {
-        [JsonProperty("accessToken")]
-        public string AccessToken { get; set; }
     }
 }

--- a/Alexa.NET/Request/Type/Converters/SkillEventRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/SkillEventRequestTypeConverter.cs
@@ -22,6 +22,11 @@
                 return new PermissionSkillEventRequest();
             }
 
+            if (requestType == "AlexaSkillEvent.SkillDisabled" || requestType == "AlexaSkillEvent.SkillEnabled")
+            {
+                return new SkillEnablementSkillEventRequest();
+            }
+
             return new SkillEventRequest();
         }
     }

--- a/Alexa.NET/Request/Type/PermissionSkillEventRequest.cs
+++ b/Alexa.NET/Request/Type/PermissionSkillEventRequest.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace Alexa.NET.Request.Type
 {
-    public class PermissionSkillEventRequest:Request
+    public class PermissionSkillEventRequest:SkillEventRequest
     {
         [JsonProperty("body")]
         public SkillEventPermissions Body { get; set; }

--- a/Alexa.NET/Request/Type/PersistenceStatus.cs
+++ b/Alexa.NET/Request/Type/PersistenceStatus.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace Alexa.NET.Request.Type
+{
+    public enum PersistenceStatus
+    {
+        [EnumMember(Value= "PERSISTED")]
+        Persisted,
+        [EnumMember(Value= "NOT_PERSISTED")]
+        NotPersisted
+    }
+}

--- a/Alexa.NET/Request/Type/SkillEnablementSkillEventRequest.cs
+++ b/Alexa.NET/Request/Type/SkillEnablementSkillEventRequest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request.Type
+{
+    public class SkillEnablementSkillEventRequest: SkillEventRequest
+    {
+        [JsonProperty("body",NullValueHandling = NullValueHandling.Ignore)]
+        public SkillEventPersistenceStatus Body { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/SkillEventPersistenceStatus.cs
+++ b/Alexa.NET/Request/Type/SkillEventPersistenceStatus.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alexa.NET.Request.Type
+{
+    public class SkillEventPersistenceStatus
+    {
+        [JsonProperty("userInformationPersistenceStatus"),
+         JsonConverter(typeof(StringEnumConverter))]
+        public PersistenceStatus Status { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/SkillEventRequest.cs
+++ b/Alexa.NET/Request/Type/SkillEventRequest.cs
@@ -1,10 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Alexa.NET.Helpers;
+using Newtonsoft.Json;
 
 namespace Alexa.NET.Request.Type
 {
     public class SkillEventRequest:Request
     {
+        [JsonProperty("eventCreationTime", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(MixedDateTimeConverter))]
+        public DateTime? EventCreationTime { get; set; }
+
+        [JsonProperty("eventPublishingTime", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(MixedDateTimeConverter))]
+        public DateTime? EventPublishingTime { get; set; }
     }
 }


### PR DESCRIPTION
In order to fix #176 I've created another request type for the SkillEventConverter that specifically handles the skill enabled and skill disabled event rather than falling back to the generic one.

I've also added two new fields which are to be used by events as a preference to Timestamp (timestamp is being obsoleted). Updated the tests for these two new fields.

Tidied up a couple of class files in the skill event area which had multiple classes in them.

Information on the SkillEvents we're now supporting:
https://developer.amazon.com/docs/smapi/skill-events-in-alexa-skills.html#skill-enabled-event

Information on the two new fields used by skill events:
https://developer.amazon.com/docs/smapi/skill-events-in-alexa-skills.html#event-creation-and-publishing-fields
