### PR TITLE
Add constructor to OutputSpeech

### DIFF
--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -737,6 +737,14 @@ namespace Alexa.NET.Tests
             Assert.Equal("testing output", plainText.Text);
         }
 
+        [Fact]
+        public void SsmlTextConstructorSetsText()
+        {
+            var output = new Speech(new PlainText("testing output")).ToXml();
+            var ssmlText = new SsmlOutputSpeech(output);
+            Assert.Equal(output, ssmlText.Ssml);
+        }
+
         private bool CompareJson(object actual, JObject expected)
         {
             var actualJObject = JObject.FromObject(actual);

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -730,6 +730,13 @@ namespace Alexa.NET.Tests
             Assert.Equal("Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless.", simpleCard.Content);
         }
 
+        [Fact]
+        public void PlainTextConstructorSetsText()
+        {
+            var plainText = new PlainTextOutputSpeech("testing output");
+            Assert.Equal("testing output", plainText.Text);
+        }
+
         private bool CompareJson(object actual, JObject expected)
         {
             var actualJObject = JObject.FromObject(actual);

--- a/Alexa.NET/Response/PlainTextOutputSpeech.cs
+++ b/Alexa.NET/Response/PlainTextOutputSpeech.cs
@@ -4,6 +4,16 @@ namespace Alexa.NET.Response
 {
     public class PlainTextOutputSpeech : IOutputSpeech
     {
+        public PlainTextOutputSpeech()
+        {
+
+        }
+
+        public PlainTextOutputSpeech(string text)
+        {
+            Text = text;
+        }
+
         [JsonProperty("type")]
         [JsonRequired]
         public string Type

--- a/Alexa.NET/Response/SsmlOutputSpeech.cs
+++ b/Alexa.NET/Response/SsmlOutputSpeech.cs
@@ -4,6 +4,16 @@ namespace Alexa.NET.Response
 {
     public class SsmlOutputSpeech : IOutputSpeech
     {
+        public SsmlOutputSpeech()
+        {
+
+        }
+
+        public SsmlOutputSpeech(string ssml)
+        {
+            Ssml = ssml;
+        }
+
         [JsonRequired]
         [JsonProperty("type")]
         public string Type


### PR DESCRIPTION
Just allows a simpler way of setting text without using property initialisers

Added a test to ensure the text is set