### PR TITLE
Fix NullReferenceException if request type is null

### DIFF
--- a/Alexa.NET/Request/Type/Converters/AudioPlayerRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/AudioPlayerRequestTypeConverter.cs
@@ -4,7 +4,7 @@
     {
         public bool CanConvert(string requestType)
         {
-            return requestType.StartsWith("AudioPlayer");
+            return requestType != null && requestType.StartsWith("AudioPlayer");
         }
 
         public Request Convert(string requestType)

--- a/Alexa.NET/Request/Type/Converters/PlaybackRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/PlaybackRequestTypeConverter.cs
@@ -4,7 +4,7 @@
     {
         public bool CanConvert(string requestType)
         {
-            return requestType.StartsWith("PlaybackController");
+            return requestType != null && requestType.StartsWith("PlaybackController");
         }
 
         public Request Convert(string requestType)

--- a/Alexa.NET/Request/Type/Converters/SkillEventRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/Converters/SkillEventRequestTypeConverter.cs
@@ -7,7 +7,7 @@
             return requestType == "AlexaSkillEvent.SkillPermissionAccepted" ||
                    requestType == "AlexaSkillEvent.SkillPermissionChanged" ||
                    requestType == "AlexaSkillEvent.SkillAccountLinked" ||
-                   requestType.StartsWith("AlexaSkillEvent");
+                   requestType != null && requestType.StartsWith("AlexaSkillEvent");
         }
 
         public Request Convert(string requestType)


### PR DESCRIPTION
Prevent `NullReferenceException` when deserializing requests if the request type is null.

I found this by chance while writing some "integration" tests for an Alexa skill of my own where I'd forgotten to set the value before passing serializing the request to pass into the function. This then meant that the deserializer threw an exception before invoking the function handler.

```json
{
  "errorType": "JsonSerializerException",
  "errorMessage": "Error converting the Lambda event JSON payload to type Alexa.NET.Request.SkillRequest: Object reference not set to an instance of an object.",
  "stackTrace": [
    "at Amazon.Lambda.Serialization.Json.JsonSerializer.Deserialize[T](Stream requestStream)",
    "at Amazon.Lambda.RuntimeSupport.HandlerWrapper.<>c__DisplayClass25_0`2.<<GetHandlerWrapper>b__0>d.MoveNext()",
    "--- End of stack trace from previous location where exception was thrown ---",
    "at Amazon.Lambda.RuntimeSupport.LambdaBootstrap.InvokeOnceAsync()"
  ],
  "cause":   {
    "errorType": "NullReferenceException",
    "errorMessage": "Object reference not set to an instance of an object.",
    "stackTrace": [
      "at Alexa.NET.Request.Type.AudioPlayerRequestTypeConverter.CanConvert(String requestType)",
      "at Alexa.NET.Request.Type.RequestConverter.<>c__DisplayClass6_0.<Create>b__0(IRequestTypeConverter c)",
      "at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)",
      "at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)",
      "at Alexa.NET.Request.Type.RequestConverter.Create(String requestType)",
      "at Alexa.NET.Request.Type.RequestConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)",
      "at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)",
      "at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)",
      "at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)",
      "at Amazon.Lambda.Serialization.Json.JsonSerializer.Deserialize[T](Stream requestStream)"
    ]
  }
}
```

Now the user gets an error similar to the following response from the Lambda instead, making the problem easier to diagnose:

```json
{
  "errorType": "JsonSerializerException",
  "errorMessage": "Error converting the Lambda event JSON payload to type Alexa.NET.Request.SkillRequest: Unknown request type: . (Parameter 'Type')",
  "stackTrace": [
    "at Amazon.Lambda.Serialization.Json.JsonSerializer.Deserialize[T](Stream requestStream)",
    "at Amazon.Lambda.RuntimeSupport.HandlerWrapper.<>c__DisplayClass25_0`2.<<GetHandlerWrapper>b__0>d.MoveNext()",
    "--- End of stack trace from previous location where exception was thrown ---",
    "at Amazon.Lambda.RuntimeSupport.LambdaBootstrap.InvokeOnceAsync()"
  ],
  "cause":   {
    "errorType": "ArgumentOutOfRangeException",
    "errorMessage": "Unknown request type: . (Parameter 'Type')",
    "stackTrace": [
      "at Alexa.NET.Request.Type.RequestConverter.Create(String requestType)",
      "at Alexa.NET.Request.Type.RequestConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)",
      "at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)",
      "at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)",
      "at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)",
      "at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)",
      "at Amazon.Lambda.Serialization.Json.JsonSerializer.Deserialize[T](Stream requestStream)"
    ]
  }
}
```