### PR TITLE
Make request mandatory

### DIFF
--- a/Alexa.NET.Tests/SkillConnectionTests.cs
+++ b/Alexa.NET.Tests/SkillConnectionTests.cs
@@ -44,6 +44,7 @@ namespace Alexa.NET.Tests
                 RequestId = "string",
                 Timestamp = new DateTime(2019, 07, 03),
                 Locale = "en-GB",
+                Type = "SessionResumedRequest",
                 OriginIpAddress = "string",
                 Cause = new SessionResumedRequestCause
                 {

--- a/Alexa.NET/Request/Type/Request.cs
+++ b/Alexa.NET/Request/Type/Request.cs
@@ -7,7 +7,7 @@ namespace Alexa.NET.Request.Type
     [JsonConverter(typeof(RequestConverter))]
     public abstract class Request
     {
-        [JsonProperty("type")]
+        [JsonProperty("type",Required = Required.Always)]
         public string Type { get; set; }
 
         [JsonProperty("requestId")]


### PR DESCRIPTION
Makes the `Type` property in our base request object mandatory to help developers understand this need during testing.

An alternative to #180 which provides better context. We actually had a test fail when I made the change - the error JSON.Net will produce is

` Newtonsoft.Json.JsonSerializationException : Cannot write a null value for property 'type'`