### PR TITLE
JSON Directive

### DIFF
--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -792,6 +792,21 @@ namespace Alexa.NET.Tests
             Assert.Equal(output, ssmlText.Ssml);
         }
 
+        [Fact]
+        public void NewDirectiveSupport()
+        {
+            var directive = new JsonDirective("UnknownDirectiveType");
+            directive.Properties.Add("testProperty",new JObject(new JProperty("value","test")));
+            var jsonOutput = JsonConvert.SerializeObject(directive);
+
+            var outputDirective = JsonConvert.DeserializeObject<IDirective>(jsonOutput);
+            var jsonInput = Assert.IsType<JsonDirective>(outputDirective);
+            Assert.Equal("UnknownDirectiveType",jsonInput.Type);
+            Assert.True(jsonInput.Properties.ContainsKey("testProperty"));
+            var jsonObject = Assert.IsType<JObject>(jsonInput.Properties["testProperty"]);
+            Assert.Equal("test",jsonObject.Value<string>("value"));
+        }
+
         private bool CompareJson(object actual, JObject expected)
         {
             var actualJObject = JObject.FromObject(actual);

--- a/Alexa.NET/Response/Converters/DirectiveConverter.cs
+++ b/Alexa.NET/Response/Converters/DirectiveConverter.cs
@@ -41,13 +41,16 @@ namespace Alexa.NET.Response.Converters
             var typeValue = typeKey.Value<string>();
             var hasFactory = TypeFactories.ContainsKey(typeValue);
 
-            if (!hasFactory)
-                throw new Exception(
-                    $"unable to deserialize response. " +
-                    $"unrecognized directive type '{typeValue}'"
-                );
+            IDirective directive;
 
-            var directive = TypeFactories[typeValue]();
+            if (!hasFactory)
+            {
+                directive = new JsonDirective(typeValue);
+            }
+            else
+            {
+                directive = TypeFactories[typeValue]();
+            }
 
             serializer.Populate(jsonObject.CreateReader(), directive);
 

--- a/Alexa.NET/Response/Directive/JsonDirective.cs
+++ b/Alexa.NET/Response/Directive/JsonDirective.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class JsonDirective:IDirective
+    {
+        public JsonDirective() { }
+
+        public JsonDirective(string type)
+        {
+            Type = type;
+        }
+
+        public string Type { get; }
+
+        [JsonExtensionData]
+        public Dictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+    }
+}


### PR DESCRIPTION
With the speed of feature release and the complexity of some of the object models we're now dealing with in the Alexa space, this adds a `JSONDirective` object. This services two purposes

1. A catch all for when the directive type isn't supported in deserialization
2. Gives a framework that allows users to build directives the way they want without having to fully implement the IDirective requirements.