### PR TITLE
Amazon Domain and Amazon Emotion SSML Tags

### DIFF
--- a/Alexa.NET.Tests/SsmlTests.cs
+++ b/Alexa.NET.Tests/SsmlTests.cs
@@ -255,6 +255,30 @@ namespace Alexa.NET.Tests
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void Ssml_AmazonDomain_generate_domain()
+        {
+            const string expected = @"<speak><amazon:domain name=""news"">A miniature manuscript</amazon:domain></speak>";
+
+            var xmlHost = new Speech();
+            var actual = new AmazonDomain(DomainName.News);
+            actual.Elements.Add(new PlainText("A miniature manuscript"));
+            xmlHost.Elements.Add(actual);
+            Assert.Equal(expected, xmlHost.ToXml());
+        }
+
+        [Fact]
+        public void Ssml_AmazonEmotion_generate_emotion()
+        {
+            const string expected = @"<speak><amazon:emotion name=""excited"" intensity=""medium"">Christina wins this round!</amazon:emotion></speak>";
+
+            var xmlHost = new Speech();
+            var actual = new AmazonEmotion(EmotionName.Excited, EmotionIntensity.Medium);
+            actual.Elements.Add(new PlainText("Christina wins this round!"));
+            xmlHost.Elements.Add(actual);
+            Assert.Equal(expected,xmlHost.ToXml());
+        }
+
         private void CompareXml(string expected, ISsml ssml)
         {
             var actual = ssml.ToXml().ToString(SaveOptions.DisableFormatting);

--- a/Alexa.NET/Response/Ssml/AlexaName.cs
+++ b/Alexa.NET/Response/Ssml/AlexaName.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace Alexa.NET.Response.Ssml
+{
+    public class AlexaName : ICommonSsml
+    {
+        public AlexaName() { }
+
+        public AlexaName(string personId)
+        {
+            if (string.IsNullOrWhiteSpace(personId))
+            {
+                throw new ArgumentNullException(nameof(personId), "PersonId value required for AlexaName in Ssml");
+            }
+            PersonId = personId;
+        }
+
+        public string PersonId { get; set; }
+
+        public XNode ToXml()
+        {
+            return new XElement(Namespaces.TempAlexa + "name", 
+                new XAttribute("type", "first"), new XAttribute("personId",PersonId));
+        }
+    }
+}

--- a/Alexa.NET/Response/Ssml/AmazonDomain.cs
+++ b/Alexa.NET/Response/Ssml/AmazonDomain.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Alexa.NET.Response.Ssml
+{
+    public class AmazonDomain : ICommonSsml
+    {
+        public string Name { get; set; }
+
+        public List<ISsml> Elements { get; set; } = new List<ISsml>();
+
+        public AmazonDomain(string name)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+        }
+
+        public AmazonDomain(string name, params ISsml[] elements)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Elements = elements.ToList();
+        }
+
+        public XNode ToXml()
+        {
+            return new XElement(Namespaces.TempAmazon + "domain", new XAttribute("name", Name), Elements.Select(e => e.ToXml()));
+        }
+    }
+}

--- a/Alexa.NET/Response/Ssml/AmazonEffect.cs
+++ b/Alexa.NET/Response/Ssml/AmazonEffect.cs
@@ -3,29 +3,7 @@ using System.Xml.Linq;
 
 namespace Alexa.NET.Response.Ssml
 {
-    public class AlexaName : ICommonSsml
-    {
-        public AlexaName() { }
-
-        public AlexaName(string personId)
-        {
-            if (string.IsNullOrWhiteSpace(personId))
-            {
-                throw new ArgumentNullException(nameof(personId), "PersonId value required for AlexaName in Ssml");
-            }
-            PersonId = personId;
-        }
-
-        public string PersonId { get; set; }
-
-        public XNode ToXml()
-        {
-            return new XElement(Namespaces.TempAlexa + "name", 
-                new XAttribute("type", "first"), new XAttribute("personId",PersonId));
-        }
-    }
-
-	public class AmazonEffect : ICommonSsml
+    public class AmazonEffect : ICommonSsml
 	{
 		public string Text { get; set; }
 

--- a/Alexa.NET/Response/Ssml/AmazonEmotion.cs
+++ b/Alexa.NET/Response/Ssml/AmazonEmotion.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Alexa.NET.Response.Ssml
+{
+    public class AmazonEmotion : ICommonSsml
+    {
+        public string Name { get; set; }
+
+        public string Intensity { get; set; }
+
+        public List<ISsml> Elements { get; set; } = new List<ISsml>();
+
+        public AmazonEmotion(string name, string intensity)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Intensity = intensity ?? throw new ArgumentNullException(nameof(intensity));
+        }
+
+        public AmazonEmotion(string name, string intensity, params ISsml[] elements)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Intensity = intensity ?? throw new ArgumentNullException(nameof(intensity));
+            Elements = elements.ToList();
+        }
+
+        public XNode ToXml()
+        {
+            return new XElement(Namespaces.TempAmazon + "emotion", new XAttribute("name", Name), new XAttribute("intensity", Intensity), Elements.Select(e => e.ToXml()));
+        }
+    }
+}

--- a/Alexa.NET/Response/Ssml/DomainName.cs
+++ b/Alexa.NET/Response/Ssml/DomainName.cs
@@ -1,0 +1,8 @@
+﻿namespace Alexa.NET.Response.Ssml
+{
+    public static class DomainName
+    {
+        public const string News = "news";
+        public const string Music = "music";
+    }
+}

--- a/Alexa.NET/Response/Ssml/EmotionIntensity.cs
+++ b/Alexa.NET/Response/Ssml/EmotionIntensity.cs
@@ -1,0 +1,9 @@
+﻿namespace Alexa.NET.Response.Ssml
+{
+    public static class EmotionIntensity
+    {
+        public const string Low = "low";
+        public const string Medium = "medium";
+        public const string High = "high";
+    }
+}

--- a/Alexa.NET/Response/Ssml/EmotionName.cs
+++ b/Alexa.NET/Response/Ssml/EmotionName.cs
@@ -1,0 +1,8 @@
+﻿namespace Alexa.NET.Response.Ssml
+{
+    public static class EmotionName
+    {
+        public const string Excited = "excited";
+        public const string Disappointed = "disappointed";
+    }
+}


### PR DESCRIPTION
Amazon have added a couple of new SSML Tags

`<amazon:domain>` and `<amazon:emotion>`
Domain: https://developer.amazon.com/docs/custom-skills/speech-synthesis-markup-language-ssml-reference.html#amazon-domain

Emotion: https://developer.amazon.com/docs/custom-skills/speech-synthesis-markup-language-ssml-reference.html#amazon-emotion

Also moved AlexaName tag into its own class file - just to tidy up
