### PR TITLE
Support "Ask For Permissions"

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -26,6 +26,9 @@
     <None Update="Examples\CompleteTaskDirective.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\ConnectionsResponseRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\DialogConfirmIntent.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -17,6 +17,9 @@
     <None Remove="Examples\AskForPermissionConsent.json" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="Examples\AskForPermissionsConsent.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\ClearQueueDirective.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -119,7 +122,7 @@
     <None Update="Examples\StandardCard.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Examples\AskForPermissionsConsent.json">
+    <None Update="Examples\AskForPermissionsConsentDirective.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Examples\Resolution.json">

--- a/Alexa.NET.Tests/Examples/AskForPermissionsConsent.json
+++ b/Alexa.NET.Tests/Examples/AskForPermissionsConsent.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "type": "AskForPermissionsConsent",
   "permissions": [
     "read::alexa:household:list"

--- a/Alexa.NET.Tests/Examples/AskForPermissionsConsentDirective.json
+++ b/Alexa.NET.Tests/Examples/AskForPermissionsConsentDirective.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "Connections.SendRequest",
+  "name": "AskFor",
+  "payload": {
+    "@type": "AskForPermissionsConsentRequest",
+    "@version": "1",
+    "permissionScope": "alexa::alerts:reminders:skill:readwrite"
+  },
+  "token": ""
+}

--- a/Alexa.NET.Tests/Examples/ConnectionsResponseRequest.json
+++ b/Alexa.NET.Tests/Examples/ConnectionsResponseRequest.json
@@ -1,0 +1,16 @@
+{
+  "type": "Connections.Response",
+  "requestId": "string",
+  "timestamp": "2015-05-13T12:34:56Z",
+  "locale": "en-US",
+  "name": "AskFor",
+  "status": {
+    "code": "200",
+    "message": "Test Message"
+  },
+  "token": "string",
+  "payload": {
+    "permissionScope": "alexa::alerts:reminders:skill:readwrite",
+    "status": "DENIED"
+  }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -335,6 +335,7 @@ namespace Alexa.NET.Tests
             Assert.Equal("alexa::alerts:reminders:skill:readwrite",askFor.Payload.PermissionScope);
             Assert.Equal(200,askFor.Status.Code);
             Assert.Equal("Test Message",askFor.Status.Message);
+            Utility.CompareJson(askFor, "ConnectionsResponseRequest.json");
         }
 
         private T GetObjectFromExample<T>(string filename)

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -325,6 +325,18 @@ namespace Alexa.NET.Tests
             Assert.Equal("Atza|BBBBBBB", request.Context.System.Person.AccessToken);
         }
 
+        [Fact]
+        public void HandleConnectionsSendResponseRequest()
+        {
+            var request = GetObjectFromExample<Request.Type.Request>("ConnectionsResponseRequest.json");
+            var askFor = Assert.IsType<AskForPermissionRequest>(request);
+            Assert.Equal("AskFor",askFor.Name);
+            Assert.Equal(PermissionStatus.Denied,askFor.Payload.Status);
+            Assert.Equal("alexa::alerts:reminders:skill:readwrite",askFor.Payload.PermissionScope);
+            Assert.Equal(200,askFor.Status.Code);
+            Assert.Equal("Test Message",askFor.Status.Message);
+        }
+
         private T GetObjectFromExample<T>(string filename)
         {
             var json = File.ReadAllText(Path.Combine(ExamplesPath, filename));

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -807,6 +807,17 @@ namespace Alexa.NET.Tests
             Assert.Equal("test",jsonObject.Value<string>("value"));
         }
 
+        [Fact]
+        public void HandlesExampleAskForPermissionsConsentDirective()
+        {
+            var deserialized = Utility.ExampleFileContent<IDirective>("AskForPermissionsConsentDirective.json");
+            var askFor = Assert.IsType<AskForPermissionDirective>(deserialized);
+            Assert.Equal(1.ToString(),askFor.Payload.Version);
+            Assert.Equal("AskFor",askFor.Name);
+            Assert.Equal("alexa::alerts:reminders:skill:readwrite",askFor.Payload.PermissionScope);
+            Utility.CompareJson(askFor, "AskForPermissionsConsentDirective.json");
+        }
+
         private bool CompareJson(object actual, JObject expected)
         {
             var actualJObject = JObject.FromObject(actual);

--- a/Alexa.NET.Tests/SkillConnectionTests.cs
+++ b/Alexa.NET.Tests/SkillConnectionTests.cs
@@ -50,7 +50,7 @@ namespace Alexa.NET.Tests
                 {
                     Type = "ConnectionCompleted",
                     Token = "1234",
-                    Status = new TaskStatus(200, "OK")
+                    Status = new ConnectionStatus(200, "OK")
                 }
             };
             Utility.CompareJson(task, "SessionResumedRequest.json");

--- a/Alexa.NET/Alexa.NET.csproj
+++ b/Alexa.NET/Alexa.NET.csproj
@@ -18,6 +18,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Alexa.NET/ConnectionStatus.cs
+++ b/Alexa.NET/ConnectionStatus.cs
@@ -1,12 +1,12 @@
 ﻿using Newtonsoft.Json;
 
-namespace Alexa.NET.ConnectionTasks
+namespace Alexa.NET
 {
-    public class TaskStatus
+    public class ConnectionStatus
     {
-        public TaskStatus() { }
+        public ConnectionStatus() { }
 
-        public TaskStatus(int code, string message)
+        public ConnectionStatus(int code, string message)
         {
             Code = code;
             Message = message;

--- a/Alexa.NET/Request/Type/AskForPermissionRequest.cs
+++ b/Alexa.NET/Request/Type/AskForPermissionRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace Alexa.NET.Request.Type
+{
+    public class AskForPermissionRequest : ConnectionResponseRequest<AskForPermissionRequestPayload>
+    {
+    }
+}

--- a/Alexa.NET/Request/Type/AskForPermissionRequestPayload.cs
+++ b/Alexa.NET/Request/Type/AskForPermissionRequestPayload.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alexa.NET.Request.Type
+{
+    public class AskForPermissionRequestPayload
+    {
+        [JsonProperty("permissionScope")]
+        public string PermissionScope { get; set; }
+
+        [JsonProperty("status"), JsonConverter(typeof(StringEnumConverter))]
+        public PermissionStatus Status { get; set; }
+    }
+
+    public enum PermissionStatus
+    {
+        [EnumMember(Value = "ACCEPTED")]
+        Accepted,
+        [EnumMember(Value = "DENIED")]
+        Denied,
+        [EnumMember(Value = "NOT_ANSWERED")]
+        NotAccepted
+    }
+}

--- a/Alexa.NET/Request/Type/AskForRequestHandler.cs
+++ b/Alexa.NET/Request/Type/AskForRequestHandler.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.Request.Type
+{
+    //https://developer.amazon.com/en-US/docs/alexa/smapi/voice-permissions-for-reminders.html#send-a-connectionssendrequest-directive
+    public class AskForRequestHandler : IConnectionResponseHandler
+    {
+        public bool CanCreate(JObject data)
+        {
+            return data.Value<string>("name") == "AskFor";
+        }
+
+        public ConnectionResponseRequest Create(JObject data)
+        {
+            return new AskForPermissionRequest();
+        }
+    }
+}

--- a/Alexa.NET/Request/Type/ConnectionResponseRequest.cs
+++ b/Alexa.NET/Request/Type/ConnectionResponseRequest.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request.Type
+{
+    public class ConnectionResponseRequest<T> : ConnectionResponseRequest
+    {
+        [JsonProperty("payload")]
+        public T Payload { get; set; }
+    }
+
+    public class ConnectionResponseRequest:Request
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("status")]
+        public ConnectionStatus Status { get; set; }
+
+        [JsonProperty("token")]
+        public string Token { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Type/ConnectionResponseTypeConverter.cs
+++ b/Alexa.NET/Request/Type/ConnectionResponseTypeConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.Request.Type
+{
+    public class ConnectionResponseTypeConverter : IDataDrivenRequestTypeConverter
+    {
+        public static List<IConnectionResponseHandler> Handlers = new List<IConnectionResponseHandler>
+        {
+            new AskForRequestHandler()
+        };
+        public bool CanConvert(string requestType)
+        {
+            return requestType == "Connections.Response";
+        }
+
+        public Request Convert(string requestType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Request Convert(JObject data)
+        {
+            var handler = Handlers.FirstOrDefault(h => h.CanCreate(data));
+            return handler?.Create(data);
+        }
+    }
+}

--- a/Alexa.NET/Request/Type/IConnectionResponseHandler.cs
+++ b/Alexa.NET/Request/Type/IConnectionResponseHandler.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.Request.Type
+{
+    public interface IConnectionResponseHandler
+    {
+        bool CanCreate(JObject data);
+        ConnectionResponseRequest Create(JObject data);
+    }
+}

--- a/Alexa.NET/Request/Type/IDataDrivenRequestTypeConverter.cs
+++ b/Alexa.NET/Request/Type/IDataDrivenRequestTypeConverter.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.Request.Type
+{
+    public interface IDataDrivenRequestTypeConverter : IRequestTypeConverter
+    {
+        Request Convert(JObject data);
+    }
+}

--- a/Alexa.NET/Request/Type/SessionResumedRequestCause.cs
+++ b/Alexa.NET/Request/Type/SessionResumedRequestCause.cs
@@ -12,7 +12,7 @@ namespace Alexa.NET.Request.Type
         public string Token { get; set; }
 
         [JsonProperty("status")]
-        public TaskStatus Status { get; set; }
+        public ConnectionStatus Status { get; set; }
 
         [JsonProperty("result")]
         public object Result { get; set; }

--- a/Alexa.NET/Response/Converters/DirectiveConverter.cs
+++ b/Alexa.NET/Response/Converters/DirectiveConverter.cs
@@ -29,6 +29,12 @@ namespace Alexa.NET.Response.Converters
             { "Dialog.UpdateDynamicEntities", () => new DialogUpdateDynamicEntities() }
         };
 
+        public static Dictionary<string, Func<JObject, IDirective>> DataDrivenTypeFactory =
+            new Dictionary<string, Func<JObject, IDirective>>
+            {
+                {"Connections.SendRequest", ConnectionSendRequestFactory.Create}
+            };
+
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
@@ -39,17 +45,22 @@ namespace Alexa.NET.Response.Converters
             var jsonObject = JObject.Load(reader);
             var typeKey = jsonObject["type"] ?? jsonObject["Type"];
             var typeValue = typeKey.Value<string>();
-            var hasFactory = TypeFactories.ContainsKey(typeValue);
+            var hasTypeFactory = TypeFactories.ContainsKey(typeValue);
+            var dataTypeFactory = DataDrivenTypeFactory.ContainsKey(typeValue);
 
             IDirective directive;
 
-            if (!hasFactory)
+            if (hasTypeFactory)
             {
-                directive = new JsonDirective(typeValue);
+                directive = TypeFactories[typeValue]();
+            }
+            else if(dataTypeFactory)
+            {
+                directive = DataDrivenTypeFactory[typeValue](jsonObject);
             }
             else
             {
-                directive = TypeFactories[typeValue]();
+                directive = new JsonDirective(typeValue);
             }
 
             serializer.Populate(jsonObject.CreateReader(), directive);

--- a/Alexa.NET/Response/Directive/AskForPermissionDirective.cs
+++ b/Alexa.NET/Response/Directive/AskForPermissionDirective.cs
@@ -1,0 +1,15 @@
+﻿namespace Alexa.NET.Response.Directive
+{
+    public class AskForPermissionDirective : ConnectionSendRequest<AskForPermissionPayload>
+    {
+        public AskForPermissionDirective()
+        {
+            
+        }
+
+        public AskForPermissionDirective(string permissionScope)
+        {
+            this.Payload = new AskForPermissionPayload(permissionScope);
+        }
+    }
+}

--- a/Alexa.NET/Response/Directive/AskForPermissionDirectiveHandler.cs
+++ b/Alexa.NET/Response/Directive/AskForPermissionDirectiveHandler.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class AskForPermissionDirectiveHandler : IConnectionSendRequestHandler
+    {
+        public bool CanCreate(JObject data)
+        {
+            return data.Value<string>("name") == "AskFor";
+        }
+
+        public ConnectionSendRequest Create()
+        {
+            return new AskForPermissionDirective();
+        }
+    }
+}

--- a/Alexa.NET/Response/Directive/AskForPermissionPayload.cs
+++ b/Alexa.NET/Response/Directive/AskForPermissionPayload.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class AskForPermissionPayload
+    {
+        public AskForPermissionPayload()
+        {
+
+        }
+
+        public AskForPermissionPayload(string permissionScope)
+        {
+            PermissionScope = permissionScope;
+        }
+
+        [JsonProperty("@type")] 
+        public string Type { get; set; } = "AskForPermissionsConsentRequest";
+
+        [JsonProperty("@version")] 
+        public string Version { get; set; } = "1";
+
+        [JsonProperty("permissionScope")]
+        public string PermissionScope { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Directive/CompleteTaskDirective.cs
+++ b/Alexa.NET/Response/Directive/CompleteTaskDirective.cs
@@ -12,13 +12,13 @@ namespace Alexa.NET.Response.Directive
 
         public CompleteTaskDirective(int statusCode, string statusMessage)
         {
-            Status = new TaskStatus(statusCode,statusMessage);
+            Status = new ConnectionStatus(statusCode,statusMessage);
         }
 
         [JsonProperty("type")]
         public string Type => "Tasks.CompleteTask";
 
         [JsonProperty("status")]
-        public TaskStatus Status { get; set; } 
+        public ConnectionStatus Status { get; set; } 
     }
 }

--- a/Alexa.NET/Response/Directive/ConnectionSendRequest.cs
+++ b/Alexa.NET/Response/Directive/ConnectionSendRequest.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Response.Directive
+{
+    public class ConnectionSendRequest<T> : ConnectionSendRequest
+    {
+        [JsonProperty("payload")]
+        public T Payload { get; set; }
+    }
+
+    public class ConnectionSendRequest:IDirective
+    {
+        [JsonProperty("type")] public string Type => "Connections.SendRequest";
+
+        [JsonProperty("name")] public string Name { get; set; }
+
+        [JsonProperty("token")]
+        string Token { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Directive/ConnectionsSendRequestFactory.cs
+++ b/Alexa.NET/Response/Directive/ConnectionsSendRequestFactory.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.Response.Directive
+{
+    public static class ConnectionSendRequestFactory
+    {
+        public static List<IConnectionSendRequestHandler> Handlers = new List<IConnectionSendRequestHandler>
+        {
+            new AskForPermissionDirectiveHandler()
+        };
+
+
+        public static IDirective Create(JObject data)
+        {
+            var handler = Handlers.FirstOrDefault(h => h.CanCreate(data));
+
+            if (handler == null)
+            {
+                throw new InvalidOperationException("Unable to parse Connections.SendRequest directive");
+            }
+
+            return handler.Create();
+        }
+    }
+}

--- a/Alexa.NET/Response/Directive/IConnectionSendRequestHandler.cs
+++ b/Alexa.NET/Response/Directive/IConnectionSendRequestHandler.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.Response.Directive
+{
+    public interface IConnectionSendRequestHandler
+    {
+        bool CanCreate(JObject data);
+
+        ConnectionSendRequest Create();
+    }
+}


### PR DESCRIPTION
Amazon have released the ability to ask for permissions with voice - rather than having to rely on an AskForPermissionConsentCard

Blog Article (right at the bottom): https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2019/12/New-Tools-Give-You-Better-Control-of-Publishing-Distribution-Permissions.html

The issue is they're doing this through the `Connections.SendRequest` Directive and `Connections.Response` Request - which are already used by In Skill Purchasing.

Technical Documentation on directive and request: https://developer.amazon.com/en-US/docs/alexa/smapi/voice-permissions-for-reminders.html#send-a-connectionssendrequest-directive

To ensure that this can be handled moving forward I've had to update the request and directive converters to handle the scenario where the type of request isn't enough to correctly identify the type needing to be deserialized.

Instead - the type leads to a converter, and the converter then has a number of handlers that examine the JSON and decide if they can handle them.

I've added base classes that allow this to be extensible relatively painlessly (I know what I'm going to need to update the In Skill Purchasing decision)

Also - these requests also use the connection status information previously seen as part of the Skill Task integration, so I've moved `TaskStatus` into the root and renamed it `ConnectionStatus` to avoid unnecessary duplication - I feel it's the right refactor, but it does move this change from a minor to a major as it will break any explicit typing of TaskStatus.