### PR TITLE
Allow directives to override ShouldEndSession

### DIFF
--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -841,21 +841,21 @@ namespace Alexa.NET.Tests
         }
 
         [Fact]
-        public void ContradictingEndSessionOverrideThrowsException()
+        public void ContradictingEndSessionOverrideDefaultsToExplicit()
         {
             var tell = ResponseBuilder.Tell("this should end the session");
             Assert.True(tell.Response.ShouldEndSession);
 
-            //This will error as VideoApp needs a null EndSession and FakeDirective needs true
+            //As VideoApp needs a null EndSession and FakeDirective needs false - reverts to explicit
             tell.Response.Directives.Add(new VideoAppDirective("https://example.com/test.mp4"));
             tell.Response.Directives.Add(new FakeDirective());
-            Assert.Throws<InvalidOperationException>(() => tell.Response.ShouldEndSession);
+            Assert.True(tell.Response.ShouldEndSession);
         }
 
         private class FakeDirective : IDirective, IEndSessionDirective
         {
             public string Type => "fake";
-            public bool? ShouldEndSession => true;
+            public bool? ShouldEndSession => false;
         }
 
         private bool CompareJson(object actual, JObject expected)

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -852,7 +852,7 @@ namespace Alexa.NET.Tests
             Assert.True(tell.Response.ShouldEndSession);
         }
 
-        private class FakeDirective : IDirective, IEndSessionDirective
+        private class FakeDirective : IEndSessionDirective
         {
             public string Type => "fake";
             public bool? ShouldEndSession => false;

--- a/Alexa.NET/Response/Directive/VideoAppDirective.cs
+++ b/Alexa.NET/Response/Directive/VideoAppDirective.cs
@@ -2,7 +2,7 @@
 
 namespace Alexa.NET.Response.Directive
 {
-    public class VideoAppDirective:IDirective,IEndSessionDirective
+    public class VideoAppDirective:IEndSessionDirective
     {
         public VideoAppDirective()
         {

--- a/Alexa.NET/Response/Directive/VideoAppDirective.cs
+++ b/Alexa.NET/Response/Directive/VideoAppDirective.cs
@@ -2,7 +2,7 @@
 
 namespace Alexa.NET.Response.Directive
 {
-    public class VideoAppDirective:IDirective
+    public class VideoAppDirective:IDirective,IEndSessionDirective
     {
         public VideoAppDirective()
         {
@@ -18,5 +18,7 @@ namespace Alexa.NET.Response.Directive
 
         [JsonProperty("videoItem",Required = Required.Always)]
         public VideoItem VideoItem { get; set; }
+
+        public bool? ShouldEndSession => null;
     }
 }

--- a/Alexa.NET/Response/IEndSessionDirective.cs
+++ b/Alexa.NET/Response/IEndSessionDirective.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Response
+{
+    public interface IEndSessionDirective
+    {
+        [JsonIgnore]
+        bool? ShouldEndSession { get; }
+    }
+}

--- a/Alexa.NET/Response/IEndSessionDirective.cs
+++ b/Alexa.NET/Response/IEndSessionDirective.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace Alexa.NET.Response
 {
-    public interface IEndSessionDirective
+    public interface IEndSessionDirective: IDirective
     {
         [JsonIgnore]
         bool? ShouldEndSession { get; }

--- a/Alexa.NET/Response/Response.cs
+++ b/Alexa.NET/Response/Response.cs
@@ -16,7 +16,7 @@ namespace Alexa.NET.Response
         [JsonProperty("reprompt", NullValueHandling = NullValueHandling.Ignore)]
         public Reprompt Reprompt { get; set; }
 
-        private bool? _explicitValue = null;
+        private bool? _shouldEndSession = null;
 
         [JsonProperty("shouldEndSession", NullValueHandling = NullValueHandling.Ignore)]
         public bool? ShouldEndSession
@@ -26,19 +26,19 @@ namespace Alexa.NET.Response
                 var overrideDirectives = Directives?.OfType<IEndSessionDirective>();
                 if (overrideDirectives == null || !overrideDirectives.Any())
                 {
-                    return _explicitValue;
+                    return _shouldEndSession;
                 }
 
                 var first = overrideDirectives.First().ShouldEndSession;
                 if (!overrideDirectives.All(od => od.ShouldEndSession == first))
                 {
-                    throw new InvalidOperationException("Response contains directives with incompatible ShouldEndSession requirements");
+                    return _shouldEndSession;
                 }
 
                 return first;
 
             }
-            set => _explicitValue = value;
+            set => _shouldEndSession = value;
         }
 
         [JsonProperty("directives", NullValueHandling = NullValueHandling.Ignore)]

--- a/Alexa.NET/Response/Response.cs
+++ b/Alexa.NET/Response/Response.cs
@@ -16,7 +16,7 @@ namespace Alexa.NET.Response
         [JsonProperty("reprompt", NullValueHandling = NullValueHandling.Ignore)]
         public Reprompt Reprompt { get; set; }
 
-        private bool? _shouldEndSession = null;
+        private bool? _shouldEndSession = false;
 
         [JsonProperty("shouldEndSession", NullValueHandling = NullValueHandling.Ignore)]
         public bool? ShouldEndSession


### PR DESCRIPTION
This PR deals fixes #166 - allowing directives to override the ShouldEndSession value when it's required. IT does this by introducing IEndSessionDirective as an inherited interface of IDirective (which has the JsonIgnore attribute - this doesn't affect serialization).

The example is the VideoAppDirective - where ShouldEndSession has to be null (otherwise the skill will error on the device).

The code checks if all directives with overrides have the same value - if they do - that value is returned

If there's no override, or the directives conflict about what the override should be, it reverts to the explicit value set against the response (did think about throwing an exception - but realistically in a situation where conflicting values is required - there will probably be a workaround by the team that says what the setting should be)

Other example where this could be used:
    Gadgets need null ShouldEndSession to work properly.
    Purchase flow has to end the session so the device process can take over.