### PR TITLE
Allow custom GetCertificate method in RequestVerfication

### DIFF
--- a/Alexa.NET/Request/RequestVerification.cs
+++ b/Alexa.NET/Request/RequestVerification.cs
@@ -23,14 +23,14 @@ namespace Alexa.NET.Request
             return Math.Abs(DateTimeOffset.Now.Subtract(timestamp).TotalSeconds) <= AllowedTimestampToleranceInSeconds;
         }
 
-        public static async Task<bool> Verify(string encodedSignature, Uri certificatePath, string body)
+        public static async Task<bool> Verify(string encodedSignature, Uri certificatePath, string body, Func<Uri,Task<X509Certificate2>> getCertificate = null)
         {
             if (!VerifyCertificateUrl(certificatePath))
             {
                 return false;
             }
 
-            var certificate = await GetCertificate(certificatePath);
+            var certificate = await (getCertificate ?? GetCertificate)(certificatePath);
             return Verify(encodedSignature, certificate, body);
         }
 

--- a/Alexa.NET/Request/RequestVerification.cs
+++ b/Alexa.NET/Request/RequestVerification.cs
@@ -31,6 +31,11 @@ namespace Alexa.NET.Request
             }
 
             var certificate = await GetCertificate(certificatePath);
+            return Verify(encodedSignature, certificate, body);
+        }
+
+        public static bool Verify(string encodedSignature, X509Certificate2 certificate, string body)
+        {
             if (!ValidSigningCertificate(certificate) || !VerifyChain(certificate))
             {
                 return false;


### PR DESCRIPTION
Based on the feedback of #184 this change would allow the current method of verification, where it works. If it doesn't then it allows the following without having to fork/alter code:

```csharp
 public static Task<X509Certificate2> GetCertificate(Uri certificatePath)
    {
        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
        byte[] certificate = null;
        using (var web = new WebClient())
        {
            certificate = web.DownloadData(certificatePath);
        }
        var cert = new X509Certificate2(certificate);
        return Task.FromResult(cert);
    }
...
var valid = RequestVeritication.Verify(encodedSignature, certificatePath, body, GetCertificate);
```