### PR TITLE
JsonDirective Type should be serialized to lower case

### DIFF
--- a/Alexa.NET/Response/Directive/JsonDirective.cs
+++ b/Alexa.NET/Response/Directive/JsonDirective.cs
@@ -14,6 +14,7 @@ namespace Alexa.NET.Response.Directive
             Type = type;
         }
 
+        [JsonProperty("type")]
         public string Type { get; }
 
         [JsonExtensionData]


### PR DESCRIPTION
Hello,

I attempted the following code referring https://github.com/stoiveyp/Alexa.NET.APL#if-you-already-have-a-json-layout but alexa claimed an error.
```
  var directive = new JsonDirective(RenderDocumentDirective.APLDirectiveType);
  directive.Properties.Add("document",aplDocumentJson);
```
According to the generated response, I suppose `Type` should be serialized to lower case `type`.