### PR TITLE
Correct intent request serialization

### DIFF
--- a/Alexa.NET.Tests/Examples/IntentRequest.json
+++ b/Alexa.NET.Tests/Examples/IntentRequest.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "1.0",
+  "version": "1.0",
   "session": {
     "new": false,
     "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
@@ -19,7 +19,7 @@
       "permissions": null
     }
   },
-    "context": null,
+  "context": null,
   "request": {
     "type": "IntentRequest",
     "dialogState": "IN_PROGRESS",

--- a/Alexa.NET.Tests/Examples/IntentRequest.json
+++ b/Alexa.NET.Tests/Examples/IntentRequest.json
@@ -1,41 +1,45 @@
 ﻿{
     "version": "1.0",
-    "session": {
-        "new": false,
-        "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
-        "application": {
-            "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
-        },
-        "attributes": {
-            "supportedHoroscopePeriods": {
-                "daily": true,
-                "weekly": false,
-                "monthly": false
-            }
-        },
-        "user": {
-            "userId": "amzn1.account.AM3B00000000000000000000000"
-        }
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
     },
-    "request": {
-      "type": "IntentRequest",
-      "dialogState":  "IN_PROGRESS",
-        "requestId": " amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
-        "timestamp": "2015-05-13T12:34:56Z",
-        "intent": {
-          "name": "GetZodiacHoroscopeIntent",
-          "confirmationStatus": "DENIED",
-            "slots": {
-              "ZodiacSign": {
-                "name": "ZodiacSign",
-                "value": "virgo"
-              },
-              "Date": {
-                "name": "Date",
-                "value": "2015-11-25",
-                "confirmationStatus": "CONFIRMED"
-              }
-            }
-        }
+    "attributes": {
+      "supportedHoroscopePeriods": {
+        "daily": true,
+        "weekly": false,
+        "monthly": false
+      }
+    },
+    "user": {
+      "userId": "amzn1.account.AM3B00000000000000000000000",
+      "accessToken": null,
+      "permissions": null
     }
+  },
+    "context": null,
+  "request": {
+    "type": "IntentRequest",
+    "dialogState": "IN_PROGRESS",
+    "requestId": " amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "locale": null,
+    "intent": {
+      "name": "GetZodiacHoroscopeIntent",
+      "confirmationStatus": "DENIED",
+      "slots": {
+        "ZodiacSign": {
+          "name": "ZodiacSign",
+          "value": "virgo"
+        },
+        "Date": {
+          "name": "Date",
+          "value": "2015-11-25",
+          "confirmationStatus": "CONFIRMED"
+        }
+      }
+    }
+  }
 }

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -21,6 +21,7 @@ namespace Alexa.NET.Tests
 
             Assert.NotNull(convertedObj);
             Assert.Equal(typeof(IntentRequest), convertedObj.GetRequestType());
+            Assert.True(Utility.CompareJson(convertedObj,IntentRequestFile));
         }
 
         [Fact]

--- a/Alexa.NET.Tests/Utility.cs
+++ b/Alexa.NET.Tests/Utility.cs
@@ -16,7 +16,6 @@ namespace Alexa.NET.Tests
             var actualJObject = JObject.FromObject(actual);
             var expected = File.ReadAllText(Path.Combine(ExamplesPath, expectedFile));
             var expectedJObject = JObject.Parse(expected);
-            Console.WriteLine(actualJObject);
             return JToken.DeepEquals(expectedJObject, actualJObject);
         }
 

--- a/Alexa.NET/Request/Type/IntentRequest.cs
+++ b/Alexa.NET/Request/Type/IntentRequest.cs
@@ -7,6 +7,7 @@ namespace Alexa.NET.Request.Type
         [JsonProperty("dialogState")]
         public string DialogState { get; set; }
 
+        [JsonProperty("intent")]
         public Intent Intent { get; set; }
     }
 }


### PR DESCRIPTION
When we serialize intent request objects, intent is output as `Intent` not `intent`.

Not a problem for reading requests into a skill - but a problem for generating test output or JSON comparison (just found it when testing Skill Invocation and Simulation changes within Alexa.NET.Management

Several properties that aren't need which we output as null - but I've left these for now and just updated the test file.