### PR TITLE
Update card image serialization

### DIFF
--- a/Alexa.NET/Response/CardImage.cs
+++ b/Alexa.NET/Response/CardImage.cs
@@ -4,12 +4,10 @@ namespace Alexa.NET.Response
 {
     public class CardImage
     {
-        [JsonProperty("smallImageUrl")]
-        [JsonRequired]
+        [JsonProperty("smallImageUrl",NullValueHandling = NullValueHandling.Ignore)]
         public string SmallImageUrl { get; set; }
 
-        [JsonProperty("largeImageUrl")]
-        [JsonRequired]
+        [JsonProperty("largeImageUrl", NullValueHandling = NullValueHandling.Ignore)]
         public string LargeImageUrl { get; set; }
     }
 }


### PR DESCRIPTION
Made card image types optional instead of required. Fixes #201

As the issue states - documentation now says "if you only provide one image" - so that's a valid scenario we don't allow with the existing CardImage.

https://developer.amazon.com/en-US/docs/alexa/custom-skills/include-a-card-in-your-skills-response.html#image_size