### PR TITLE
Cache certs

### DIFF
--- a/Alexa.NET/Request/RequestVerification.cs
+++ b/Alexa.NET/Request/RequestVerification.cs
@@ -12,7 +12,7 @@ namespace Alexa.NET.Request
     public static class RequestVerification
     {
         private const int AllowedTimestampToleranceInSeconds = 150;
-        private IDictionary<Uri, X509Certificate2> CachedCerts { get; } = new Dictionary<Uri, X509Certificate2>();
+        private static IDictionary<Uri, X509Certificate2> CachedCerts { get; } = new Dictionary<Uri, X509Certificate2>();
 
         public static bool RequestTimestampWithinTolerance(SkillRequest request)
         {

--- a/Alexa.NET/Request/RequestVerification.cs
+++ b/Alexa.NET/Request/RequestVerification.cs
@@ -39,11 +39,13 @@ namespace Alexa.NET.Request
         {
             if (!ValidSigningCertificate(certificate) || !VerifyChain(certificate))
             {
+                CachedCerts.Remove(CachedCerts.FirstOrDefault(x => x.Value == certificate).Key);
                 return false;
             }
 
             if (!AssertHashMatch(certificate, encodedSignature, body))
             {
+                CachedCerts.Remove(CachedCerts.FirstOrDefault(x => x.Value == certificate).Key);
                 return false;
             }
 


### PR DESCRIPTION
I noticed the default implementation of RequestVerification.Verify was slow. (~500ms from my basement in Nebraska) 

This is one way to speed it up.  (after first request <2ms)