### PR TITLE
Alternative Cached Certificates

### DIFF
--- a/Alexa.NET/Request/CachedCertificateHandler.cs
+++ b/Alexa.NET/Request/CachedCertificateHandler.cs
@@ -19,15 +19,13 @@ namespace Alexa.NET.Request
             return _cache.AddOrUpdate(uri, cert, (u,c) => cert);
         }
 
-        public Task OnCertificateValidationFailed(X509Certificate2 certificate)
+        public void OnCertificateValidationFailed(X509Certificate2 certificate)
         {
             var pair = _cache.FirstOrDefault(kvp => kvp.Value == certificate);
             if (pair.Key != default)
             {
                 _cache.TryRemove(pair.Key, out _);
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/Alexa.NET/Request/CachedCertificateHandler.cs
+++ b/Alexa.NET/Request/CachedCertificateHandler.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Alexa.NET.Request
+{
+    public class CachedCertificateHandler : ICertificateHandler
+    {
+        public ConcurrentDictionary<Uri, X509Certificate2> _cache = new ConcurrentDictionary<Uri, X509Certificate2>();
+        public async Task<X509Certificate2> GetCertificate(Uri uri)
+        {
+            if(_cache.TryGetValue(uri, out var cert))
+            {
+                return cert;
+            }
+            cert = await RequestVerification.GetCertificate(uri);
+            return _cache.AddOrUpdate(uri, cert, (u,c) => cert);
+        }
+
+        public Task OnCertificateValidationFailed(X509Certificate2 certificate)
+        {
+            var pair = _cache.FirstOrDefault(kvp => kvp.Value == certificate);
+            if (pair.Key != default)
+            {
+                _cache.TryRemove(pair.Key, out _);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Alexa.NET/Request/ICertificateHandler.cs
+++ b/Alexa.NET/Request/ICertificateHandler.cs
@@ -7,6 +7,6 @@ namespace Alexa.NET.Request
     public interface ICertificateHandler
     {
         Task<X509Certificate2> GetCertificate(Uri uri);
-        Task OnCertificateValidationFailed(X509Certificate2 certificate);
+        void OnCertificateValidationFailed(X509Certificate2 certificate);
     }
 }

--- a/Alexa.NET/Request/ICertificateHandler.cs
+++ b/Alexa.NET/Request/ICertificateHandler.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Alexa.NET.Request
+{
+    public interface ICertificateHandler
+    {
+        Task<X509Certificate2> GetCertificate(Uri uri);
+        Task OnCertificateValidationFailed(X509Certificate2 certificate);
+    }
+}


### PR DESCRIPTION
Showing my view of cached certificates with some code.

This approach is more internal code, but less for our users. So if we decided to leave things as they were - we'd end up with this code to turn on caching

```csharp
RequestVerification.CertificateHandler = new CachedCertificateHandler()
```

and if we changed to Cached by default you give CertificateHandler the cache as a default value, and it's a one liner to change it back
```csharp
RequestVerification.CertificateHandler = null;
```

Regardless of which approach was decided any existing implementations would be left as is, because the existing signature hasn't changed and the order of importance is inline lambda -> CertificateHandler -> GetCertificate

As GetCertificate is public, it means if anyone was using the method before anywhere else, it's still good.
