### PR TITLE
Add support for Multi-Value Slot

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -65,6 +65,9 @@
     <None Update="Examples\LinkAccountCard.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\MultiValueSlot.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\NewIntent.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Examples/MultiValueSlot.json
+++ b/Alexa.NET.Tests/Examples/MultiValueSlot.json
@@ -1,0 +1,76 @@
+{
+  "toppings": {
+    "name": "toppings",
+    "confirmationStatus": "NONE",
+    "source": "USER",
+    "slotValue": {
+      "type": "List",
+      "values": [
+        {
+          "type": "Simple",
+          "value": "olives",
+          "resolutions": {
+            "resolutionsPerAuthority": [
+              {
+                "authority": "amzn1.er-authority.echo-sdk.amzn1.ask.skill.1.PizzaToppings",
+                "status": {
+                  "code": "ER_SUCCESS_MATCH"
+                },
+                "values": [
+                  {
+                    "value": {
+                      "name": "black olives",
+                      "id": "OLIVES_BLACK"
+                    }
+                  },
+                  {
+                    "value": {
+                      "name": "green olives",
+                      "id": "OLIVES_GREEN"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "Simple",
+          "value": "sausage",
+          "resolutions": {
+            "resolutionsPerAuthority": [
+              {
+                "authority": "amzn1.er-authority.echo-sdk.amzn1.ask.skill.1.PizzaToppings",
+                "status": {
+                  "code": "ER_SUCCESS_MATCH"
+                },
+                "values": [
+                  {
+                    "value": {
+                      "name": "sausage",
+                      "id": "SAUSAGE"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "Simple",
+          "value": "ham",
+          "resolutions": {
+            "resolutionsPerAuthority": [
+              {
+                "authority": "amzn1.er-authority.echo-sdk.amzn1.ask.skill.1.PizzaToppings",
+                "status": {
+                  "code": "ER_SUCCESS_NO_MATCH"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Alexa.NET.Request;
@@ -337,6 +338,14 @@ namespace Alexa.NET.Tests
             Assert.Equal(200,askFor.Status.Code);
             Assert.Equal("Test Message",askFor.Status.Message);
             Utility.CompareJson(askFor, "ConnectionsResponseRequest.json");
+        }
+
+        [Fact]
+        public void MultiValueSlot()
+        {
+            var slots = Utility.ExampleFileContent<Dictionary<string, Slot>>("MultiValueSlot.json");
+            Assert.Single(slots);
+            Assert.True(Utility.CompareJson(slots,"MultiValueSlot.json"));
         }
 
         private T GetObjectFromExample<T>(string filename)

--- a/Alexa.NET/Request/ResolutionAuthority.cs
+++ b/Alexa.NET/Request/ResolutionAuthority.cs
@@ -10,7 +10,7 @@ namespace Alexa.NET.Request
         [JsonProperty("status")]
         public ResolutionStatus Status { get; set; }
 
-        [JsonProperty("values")]
+        [JsonProperty("values", NullValueHandling = NullValueHandling.Ignore)]
         public ResolutionValueContainer[] Values { get; set; }
     }
 }

--- a/Alexa.NET/Request/Slot.cs
+++ b/Alexa.NET/Request/Slot.cs
@@ -7,13 +7,19 @@ namespace Alexa.NET.Request
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonProperty("value")]
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
         public string Value { get; set; }
 
         [JsonProperty("confirmationStatus", NullValueHandling = NullValueHandling.Ignore)]
         public string ConfirmationStatus { get; set; }
 
+        [JsonProperty("source",NullValueHandling = NullValueHandling.Ignore)]
+        public string Source { get; set; }
+
         [JsonProperty("resolutions", NullValueHandling = NullValueHandling.Ignore)]
         public Resolution Resolution { get; set; }
+
+        [JsonProperty("slotValue",NullValueHandling = NullValueHandling.Ignore)]
+        public SlotValue SlotValue { get; set; }
     }
 }

--- a/Alexa.NET/Request/SlotValue.cs
+++ b/Alexa.NET/Request/SlotValue.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alexa.NET.Request
+{
+    public class SlotValue
+    {
+        [JsonProperty("type",NullValueHandling = NullValueHandling.Ignore),
+         JsonConverter(typeof(StringEnumConverter))]
+        public SlotValueType SlotType { get; set; }
+
+        [JsonProperty("value",NullValueHandling = NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+        [JsonProperty("values",NullValueHandling = NullValueHandling.Ignore)]
+        public SlotValue[] Values { get; set; }
+
+        [JsonProperty("resolutions",NullValueHandling = NullValueHandling.Ignore)]
+        public Resolution Resolutions { get; set; }
+    }
+}

--- a/Alexa.NET/Request/SlotValueType.cs
+++ b/Alexa.NET/Request/SlotValueType.cs
@@ -1,0 +1,12 @@
+using System.Runtime.Serialization;
+
+namespace Alexa.NET.Request
+{
+    public enum SlotValueType
+    {
+        [EnumMember(Value="Simple")]
+        Simple,
+        [EnumMember(Value="List")]
+        List
+    }
+}


### PR DESCRIPTION
The Alexa team have added the capability for slots to contain multiple values, by introducing a new `slotValue` property into the slot object.

This PR updates slots so they support this (not a breaking change - slots work as they did before, the new object has to be used to handle multiple values is all)

New test added based on the technical documentation

**Amazon Blog Post:**
https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2020/07/ask-sdk--slot-management--testing--and-analytics-.html
(long article - under the section labelled "More Capable and Up-to-Date Slots")

**Technical Docs:**
https://developer.amazon.com/en-US/docs/alexa/custom-skills/collect-multiple-values-in-a-slot.html#slotvalue-object