### PR TITLE
Add option to create ConnectionTaskConverters to handle custom task i…

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -59,6 +59,9 @@
     <None Update="Examples\GetUtterance.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\LaunchRequestWithCustomTask.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\LaunchRequestWithTask.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Examples/ExampleTask.cs
+++ b/Alexa.NET.Tests/Examples/ExampleTask.cs
@@ -1,0 +1,12 @@
+﻿using Alexa.NET.ConnectionTasks;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Tests.Examples
+{
+    public class ExampleTask : IConnectionTask
+    {
+        public string ConnectionUri { get; set; }
+        [JsonProperty("randomParameter")]
+        public string RandomParameter { get; set; }
+    }
+}

--- a/Alexa.NET.Tests/Examples/ExampleTaskConverter.cs
+++ b/Alexa.NET.Tests/Examples/ExampleTaskConverter.cs
@@ -1,0 +1,31 @@
+﻿using Alexa.NET.ConnectionTasks;
+using Alexa.NET.Request.Type;
+using Alexa.NET.Response.Converters;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+
+namespace Alexa.NET.Tests.Examples
+{
+    public class ExampleTaskConverter : IConnectionTaskConverter
+    {
+        public bool CanConvert(JObject jObject)
+        {
+            var property = jObject["randomParameter"];
+            return property is object;
+        }
+
+        public IConnectionTask Convert(JObject jObject)
+        {
+            return new ExampleTask();
+        }
+
+        public static void AddToConnectionTaskConverters()
+        {
+            if (ConnectionTaskConverter.ConnectionTaskConverters.Where(rc => rc != null)
+                .All(rc => rc.GetType() != typeof(ExampleTaskConverter)))
+            {
+                ConnectionTaskConverter.ConnectionTaskConverters.Add(new ExampleTaskConverter());
+            }
+        }
+    }
+}

--- a/Alexa.NET.Tests/Examples/LaunchRequestWithCustomTask.json
+++ b/Alexa.NET.Tests/Examples/LaunchRequestWithCustomTask.json
@@ -1,0 +1,14 @@
+﻿{
+    "type": "LaunchRequest",
+    "requestId": "string",
+    "timestamp": "2019-07-03T00:00:00",
+    "locale": "string",
+    "originIpAddress": "string",
+    "task": {
+        "name": "Custom.ExampleTask",
+        "version": "1",
+        "input": {
+          "randomParameter":  "parameterValue"
+        }
+    }
+}

--- a/Alexa.NET.Tests/SkillConnectionTests.cs
+++ b/Alexa.NET.Tests/SkillConnectionTests.cs
@@ -3,7 +3,9 @@ using Alexa.NET.ConnectionTasks;
 using Alexa.NET.ConnectionTasks.Inputs;
 using Alexa.NET.Request.Type;
 using Alexa.NET.Response;
+using Alexa.NET.Response.Converters;
 using Alexa.NET.Response.Directive;
+using Alexa.NET.Tests.Examples;
 using Xunit;
 
 namespace Alexa.NET.Tests
@@ -75,6 +77,18 @@ namespace Alexa.NET.Tests
             Assert.Equal("AMAZON.PrintPDF", result.Task.Name);
             Assert.Equal("1", result.Task.Version);
             Assert.IsType<PrintPdfV1>(result.Task.Input);
+        }
+
+        [Fact]
+        public void LaunchRequestWithCustomTaskDeserializesCorrectly()
+        {
+            ExampleTaskConverter.AddToConnectionTaskConverters();
+            var result = Utility.ExampleFileContent<LaunchRequest>("LaunchRequestWithCustomTask.json");
+            Assert.NotNull(result.Task);
+            Assert.Equal("Custom.ExampleTask", result.Task.Name);
+            Assert.Equal("1", result.Task.Version);
+            Assert.IsType<ExampleTask>(result.Task.Input);
+            Assert.Equal(((ExampleTask)result.Task.Input).RandomParameter, "parameterValue");
         }
 
         [Fact]

--- a/Alexa.NET/ConnectionTasks/IConnectionTask.cs
+++ b/Alexa.NET/ConnectionTasks/IConnectionTask.cs
@@ -9,14 +9,5 @@ namespace Alexa.NET.ConnectionTasks
     {
         [JsonIgnore]
         string ConnectionUri { get; }
-
-        [JsonProperty("@type")]
-        string Type { get; }
-
-        [JsonProperty("@version")]
-        string Version { get; }
-
-        [JsonProperty("context",NullValueHandling = NullValueHandling.Ignore)]
-        ConnectionTaskContext Context { get; set; }
     }
 }

--- a/Alexa.NET/Request/Type/IConnectionTaskConverter.cs
+++ b/Alexa.NET/Request/Type/IConnectionTaskConverter.cs
@@ -1,0 +1,14 @@
+﻿using Alexa.NET.ConnectionTasks;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Alexa.NET.Request.Type
+{
+    public interface IConnectionTaskConverter
+    {
+        bool CanConvert(JObject jObject);
+        IConnectionTask Convert(JObject jObject);
+    }
+}


### PR DESCRIPTION
This should allow custom tasks inputs to be used by adding your own converters. Otherwise this shouldn't break any existing functionality. 