### PR TITLE
Patch: Add conversational style to domain name

### DIFF
--- a/Alexa.NET/Response/Ssml/DomainName.cs
+++ b/Alexa.NET/Response/Ssml/DomainName.cs
@@ -4,5 +4,6 @@
     {
         public const string News = "news";
         public const string Music = "music";
+        public const string Conversational = "conversational";
     }
 }


### PR DESCRIPTION
Amazon have increased support for speaking styles and emotion.

Low priority, one liner to add the "conversational" style to the DomainName lookup. We already support everything else mentioned in the article.

Amazon Article:
https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2020/11/alexa-speaking-styles-emotions-now-available-additional-languages