### PR TITLE
Minor: Add authenticationConfidenceLevel to person

### DIFF
--- a/Alexa.NET.Tests/Examples/BuiltInIntentRequest.json
+++ b/Alexa.NET.Tests/Examples/BuiltInIntentRequest.json
@@ -27,6 +27,9 @@
       },
       "person": {
         "personId": "amzn1.ask.account.personid",
+        "authenticationConfidenceLevel": {
+          "level": 300
+        },
         "accessToken": "Atza|BBBBBBB"
       }
     }

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -325,6 +325,7 @@ namespace Alexa.NET.Tests
             Assert.NotNull(request.Context.System.Person);
             Assert.Equal("amzn1.ask.account.personid",request.Context.System.Person.PersonId);
             Assert.Equal("Atza|BBBBBBB", request.Context.System.Person.AccessToken);
+            Assert.Equal(300,request.Context.System.Person.AuthenticationConfidenceLevel.Level);
         }
 
         [Fact]

--- a/Alexa.NET/Request/AuthenticationConfidenceLevel.cs
+++ b/Alexa.NET/Request/AuthenticationConfidenceLevel.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class AuthenticationConfidenceLevel
+    {
+        [JsonProperty("level")]
+        public int Level { get; set; }
+    }
+}

--- a/Alexa.NET/Request/Person.cs
+++ b/Alexa.NET/Request/Person.cs
@@ -9,5 +9,8 @@ namespace Alexa.NET.Request
 
         [JsonProperty("accessToken")]
         public string AccessToken { get; set; }
+
+        [JsonProperty("authenticationConfidenceLevel",NullValueHandling = NullValueHandling.Ignore)]
+        public AuthenticationConfidenceLevel AuthenticationConfidenceLevel { get; set; }
     }
 }


### PR DESCRIPTION
With the introduction of the PIN Confirmation preview for en-US skills, the Alexa team have added the authenticationConfidenceLevel property to the person information sent in the request

This has ben added as an optional property with an updated person test.
The rest of the requirements for PIN Confirmation I'm adding to a new extension which I can release after PR #219 has been merged in.

Amazon link showing new property:
https://developer.amazon.com/en-US/docs/alexa/custom-skills/pin-confirmation-for-alexa-skills.html#sessionresumedrequest-format