### PR TITLE
Minor: Add OnCompletion options to StartConnection Directive

### DIFF
--- a/Alexa.NET.Tests/Examples/ScheduleFoodEstablishmentReservation.json
+++ b/Alexa.NET.Tests/Examples/ScheduleFoodEstablishmentReservation.json
@@ -1,6 +1,7 @@
 {
   "type": "Connections.StartConnection",
   "uri": "connection://AMAZON.ScheduleFoodEstablishmentReservation/1",
+  "onComplete": "RESUME_SESSION", 
   "input": {
     "@type": "ScheduleFoodEstablishmentReservationRequest",
     "@version": "1",

--- a/Alexa.NET.Tests/SkillConnectionTests.cs
+++ b/Alexa.NET.Tests/SkillConnectionTests.cs
@@ -176,6 +176,7 @@ namespace Alexa.NET.Tests
                     }
                 }
             }.ToConnectionDirective();
+            directive.OnComplete = OnCompleteAction.ResumeSession;
             Assert.Equal(ScheduleFoodEstablishmentReservation.AssociatedUri, directive.Uri);
             Assert.True(Utility.CompareJson(directive, "ScheduleFoodEstablishmentReservation.json"));
             Assert.IsType<ScheduleFoodEstablishmentReservation>(Utility.ExampleFileContent<StartConnectionDirective>("ScheduleFoodEstablishmentReservation.json").Input);

--- a/Alexa.NET/Response/Directive/OnCompleteAction.cs
+++ b/Alexa.NET/Response/Directive/OnCompleteAction.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace Alexa.NET.Response.Directive
+{
+    public enum OnCompleteAction
+    {
+        [EnumMember(Value="RESUME_SESSION")]
+        ResumeSession,
+        [EnumMember(Value="SEND_ERRORS_ONLY")]
+        SendErrorsOnly
+    }
+}

--- a/Alexa.NET/Response/Directive/StartConnectionDirective.cs
+++ b/Alexa.NET/Response/Directive/StartConnectionDirective.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Alexa.NET.ConnectionTasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Alexa.NET.Response.Directive
 {
@@ -17,6 +18,10 @@ namespace Alexa.NET.Response.Directive
 
         [JsonProperty("token",NullValueHandling = NullValueHandling.Ignore)]
         public string Token { get; set; }
+
+        [JsonProperty("onComplete",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public OnCompleteAction? OnComplete { get; set; }
 
         public StartConnectionDirective(){}
 


### PR DESCRIPTION
StartConnection directive allows users to specify if the session is expected to be resumed after the connection task is established or not

This is an optional property with two values - I've updated one of the existing tests to ensure its working, the others take advantage of it being an optional extra to test its blank state

https://developer.amazon.com/en-US/docs/alexa/custom-skills/use-skill-connections-to-request-tasks.html#for-direct-skill-connection