### PR TITLE
Add ObsoleteAttribute to everything dealing with Display Templates

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+	  <NoWarn>CS0612,CS0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Alexa.NET/Alexa.NET.csproj
+++ b/Alexa.NET/Alexa.NET.csproj
@@ -15,7 +15,8 @@
     <RepositoryUrl>https://github.com/timheuer/alexa-skills-dotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>nuget-icon.png</PackageIcon>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+	  <NoWarn>CS0612,CS0618</NoWarn>
+	  <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <LangVersion>8</LangVersion>

--- a/Alexa.NET/Response/Directive/DisplayRenderTemplateDirective.cs
+++ b/Alexa.NET/Response/Directive/DisplayRenderTemplateDirective.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Alexa.NET.Response.Converters;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Alexa.NET.Response.Directive
 {
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public class DisplayRenderTemplateDirective : IDirective
     {
         [JsonProperty("type")]

--- a/Alexa.NET/Response/Directive/ITemplate.cs
+++ b/Alexa.NET/Response/Directive/ITemplate.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 namespace Alexa.NET.Response.Directive
 {
     [JsonConverter(typeof(TemplateConverter))]
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public interface ITemplate
     {
         [JsonProperty("type", Required = Required.Always)]

--- a/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate1.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate1.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Alexa.NET.Response.Directive.Templates.Types
 {
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public class BodyTemplate1:IBodyTemplate
     {
         public string Type => "BodyTemplate1";

--- a/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate2.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate2.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 
 namespace Alexa.NET.Response.Directive.Templates.Types
 {
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public class BodyTemplate2:IBodyTemplate
     {
         public string Type => "BodyTemplate2";

--- a/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate3.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate3.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Alexa.NET.Response.Directive.Templates.Types
 {
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public class BodyTemplate3:IBodyTemplate
     {
         public string Type => "BodyTemplate3";

--- a/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate6.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate6.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Alexa.NET.Response.Directive.Templates.Types
 {
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public class BodyTemplate6:IBodyTemplate
     {
         public string Type => "BodyTemplate6";

--- a/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate7.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/BodyTemplate7.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Alexa.NET.Response.Directive.Templates.Types
 {
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public class BodyTemplate7:IBodyTemplate
     {
         public string Type => "BodyTemplate7";

--- a/Alexa.NET/Response/Directive/Templates/Types/ListTemplate1.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/ListTemplate1.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 
 namespace Alexa.NET.Response.Directive.Templates.Types
 {
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public class ListTemplate1:IListTemplate
     {
         public string Type => "ListTemplate1";

--- a/Alexa.NET/Response/Directive/Templates/Types/ListTemplate2.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/ListTemplate2.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 
 namespace Alexa.NET.Response.Directive.Templates.Types
 {
+    [Obsolete("Display Templates are deprecated as of August 31st 2021. For more information visit https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates")]
     public class ListTemplate2:IListTemplate
     {
         public string Type => "ListTemplate2";


### PR DESCRIPTION
Display Templates are being deprecated as of August 2021. This PR adds the ObsoleteAttribute on the ITemplate interface and all classes that custom skills may be using with it

It also adds the appropriate NoWarn attribute to the projects so that the build isn't blocked by the warnings generated from using its own now obsoleted classes

Information on deprecation https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2021/06/-goodbye-display-templates--hello-alexa-responsive-templates