### PR TITLE
add specific properties support for alexa smart properties

### DIFF
--- a/Alexa.NET.Tests/Examples/SmartPropertiesIntentRequest.json
+++ b/Alexa.NET.Tests/Examples/SmartPropertiesIntentRequest.json
@@ -1,0 +1,54 @@
+{
+    "version": "1.0",
+    "session": {
+        "new": true,
+        "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+        "application": {
+            "applicationId": "amzn1.ask.skill.000000-d0ed-0000-ad00-000000d00ebe"
+        },
+        "attributes": {},
+        "user": {
+            "userId": "amzn1.ask.account.ABC12300000000000000000000000"
+        }
+    },
+    "context": {
+        "Extensions": {
+            "available": {}
+        },
+        "System": {
+            "application": {
+                "applicationId": "amzn1.ask.skill.000000-d0ed-0000-ad00-000000d00ebe"
+            },
+            "user": {
+                "userId": "amzn1.ask.account.ABC12300000000000000000000000"
+            },
+            "device": {
+                "deviceId": "amzn1.ask.device.XYZ78900000000000000000000000",
+                "supportedInterfaces": {},
+                "persistentEndpointId": "amzn1.alexa.endpoint.AABBCC010101010101010101"
+            },
+            "apiEndpoint": "https://api.eu.amazonalexa.com",
+            "apiAccessToken": "ey01010101010101010101010101",
+            "unit": {
+                "unitId": "amzn1.ask.unit.A1B2C3",
+                "persistentUnitId": "amzn1.alexa.unit.did.X7Y8Z9"
+            }
+        }
+    },
+    "request": {
+        "type": "IntentRequest",
+        "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+        "locale": "en-GB",
+        "timestamp": "2021-09-13T07:04:58Z",
+        "intent": {
+            "name": "AmenityRequestIntent",
+            "confirmationStatus": "NONE",
+            "slots": {
+                "toiletries": {
+                    "name": "toiletries",
+                    "value": "towel"
+                }
+            }
+        }
+    }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -349,6 +349,16 @@ namespace Alexa.NET.Tests
             Assert.True(Utility.CompareJson(slots,"MultiValueSlot.json"));
         }
 
+        [Fact]
+        public void HandleAlexaSmartPropertiesSupport()
+        {
+            var request = GetObjectFromExample<SkillRequest>("SmartPropertiesIntentRequest.json");
+            Assert.NotNull(request.Context.System.Unit);
+            Assert.Equal("amzn1.ask.unit.A1B2C3",request.Context.System.Unit.UnitID);
+            Assert.Equal("amzn1.alexa.unit.did.X7Y8Z9", request.Context.System.Unit.PersistentUnitID);
+            Assert.Equal("amzn1.alexa.endpoint.AABBCC010101010101010101",request.Context.System.Device.PersistentEndpointID);
+        }
+
         private T GetObjectFromExample<T>(string filename)
         {
             var json = File.ReadAllText(Path.Combine(ExamplesPath, filename));

--- a/Alexa.NET/Request/Device.cs
+++ b/Alexa.NET/Request/Device.cs
@@ -19,5 +19,8 @@ namespace Alexa.NET.Request
             var hasInterface = SupportedInterfaces?.ContainsKey(interfaceName);
             return (hasInterface.HasValue ? hasInterface.Value : false); 
         }
+
+        [JsonProperty("persistentEndpointId",NullValueHandling = NullValueHandling.Ignore)]
+        public string PersistentEndpointID { get; set; }
     }
 }

--- a/Alexa.NET/Request/System.cs
+++ b/Alexa.NET/Request/System.cs
@@ -25,5 +25,8 @@ namespace Alexa.NET.Request
 
         [JsonProperty("device")]
         public Device Device { get; set; }
+
+        [JsonProperty("unit",NullValueHandling = NullValueHandling.Ignore)]
+        public Unit Unit { get; set; }
     }
 }

--- a/Alexa.NET/Request/Unit.cs
+++ b/Alexa.NET/Request/Unit.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class Unit
+    {
+        [JsonProperty("unitId")]
+        public string UnitID { get; set; }
+
+        [JsonProperty("persistentUnitId")]
+        public string PersistentUnitID { get; set; }
+    }
+}


### PR DESCRIPTION
Hello,

To ensure request payload sent to Alexa Skills while in the context of Alexa Smart Properties (e.g Alexa for Hospitality or Alexa for Residential) is fully deserialized, a few additional properties must be added.

From the official [Request and Response JSON Reference](https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html) Alexa documentation, you can find the following properties to add into deserialization:

- `persistentEndpointId` is a persistent identifier for the endpoint from which the skill request is issued.
This property shall be added into the existing `Device` object.

- `unitId` is a string representing a unique identifier for the unit in the context of a request. 
This property shall be added into a new object named `Unit` attached to the existing `System` object.

- `persistentUnitId` is a string representing  a unique identifier for the unit in the context of a request. 
This property shall be added into a new object named `Unit` attached to the existing `System` object.

The objective of this PR is to add support for those 3 properties into the request payload sent to skills.

Thank you
Benoit