### PR TITLE
Add Pin Confirmation helpers

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -78,6 +78,12 @@
     <None Update="Examples\NewVersionRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\PinConfirmation.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\PinConfirmationSessionResumed.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\PlainTextOutputSpeech.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Examples/PinConfirmation.json
+++ b/Alexa.NET.Tests/Examples/PinConfirmation.json
@@ -1,0 +1,13 @@
+﻿{
+    "type": "Connections.StartConnection",
+    "uri": "connection://AMAZON.VerifyPerson/2",
+    "input": {
+        "requestedAuthenticationConfidenceLevel": {
+            "level": 400,
+            "customPolicy": {
+                "policyName": "VOICE_PIN"
+            }
+        }
+    },
+    "token": "example-token"
+}

--- a/Alexa.NET.Tests/Examples/PinConfirmationSessionResumed.json
+++ b/Alexa.NET.Tests/Examples/PinConfirmationSessionResumed.json
@@ -1,0 +1,18 @@
+{
+  "type": "SessionResumedRequest",
+  "requestId": "amzn1.echo-api.request.example",
+  "timestamp": "2019-10-15T03:15:43Z",
+  "locale": "en-US",
+  "cause": {
+    "type": "ConnectionCompleted",
+    "token": "Some connection token data",
+    "status": {
+      "code": "200",
+      "message": "Successfully performed PIN confirmation"
+    },
+    "result": {
+      "status": "NOT_ACHIEVED",
+      "reason": "VERIFICATION_METHOD_NOT_SETUP"
+    }
+  }
+}

--- a/Alexa.NET.Tests/SkillConnectionTests.cs
+++ b/Alexa.NET.Tests/SkillConnectionTests.cs
@@ -196,5 +196,22 @@ namespace Alexa.NET.Tests
             Assert.IsType<ScheduleFoodEstablishmentReservation>(Utility.ExampleFileContent<StartConnectionDirective>("ScheduleFoodEstablishmentReservation.json").Input);
         }
 
+        [Fact]
+        public void PinConfirmationSerializesCorrectly()
+        {
+            var task = new PinConfirmation();
+            Utility.CompareJson(task.ToConnectionDirective("none"), "PinConfirmation.json");
+        }
+
+        [Fact]
+        public void ResultDeserializesCorrectly()
+        {
+            var task = new PinConfirmation();
+            var request = Utility.ExampleFileContent<SessionResumedRequest>("PinConfirmationSessionResumed.json");
+            var result = PinConfirmationConverter.ResultFromSessionResumed(request);
+            Assert.Equal(PinConfirmationStatus.NotAchieved,result.Status);
+            Assert.Equal(PinConfirmationReason.VerificationMethodNotSetup,result.Reason);
+        }
+
     }
 }

--- a/Alexa.NET.Tests/SkillConnectionTests.cs
+++ b/Alexa.NET.Tests/SkillConnectionTests.cs
@@ -200,7 +200,7 @@ namespace Alexa.NET.Tests
         public void PinConfirmationSerializesCorrectly()
         {
             var task = new PinConfirmation();
-            Utility.CompareJson(task.ToConnectionDirective("none"), "PinConfirmation.json");
+            Assert.True(Utility.CompareJson(task.ToConnectionDirective("example-token"), "PinConfirmation.json"));
         }
 
         [Fact]

--- a/Alexa.NET/Alexa.NET.csproj
+++ b/Alexa.NET/Alexa.NET.csproj
@@ -41,10 +41,4 @@
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/Alexa.NET/Alexa.NET.csproj
+++ b/Alexa.NET/Alexa.NET.csproj
@@ -41,4 +41,10 @@
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 </Project>

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmation.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmation.cs
@@ -13,6 +13,10 @@ namespace Alexa.NET.ConnectionTasks.Inputs
 
         [JsonProperty("requestedAuthenticationConfidenceLevel")]
         public AuthenticationConfidenceLevel RequestedAuthenticationConfidenceLevel { get; } =
-            new() { Level = 400, Custom = new("VOICE_PIN")};
+            new AuthenticationConfidenceLevel { 
+                Level = 400, 
+                Custom = new AuthenticationConfidenceLevelCustomPolicy("VOICE_PIN")
+
+            };
     }
 }

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmation.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmation.cs
@@ -1,0 +1,18 @@
+﻿using Alexa.NET.Request;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.ConnectionTasks.Inputs
+{
+    public class PinConfirmation:IConnectionTask
+    {
+        public const string AssociatedUri = "connection://AMAZON.VerifyPerson/2";
+
+        //https://developer.amazon.com/en-US/docs/alexa/custom-skills/pin-confirmation-for-alexa-skills.html#connections-startconnection-format
+        [JsonIgnore]
+        public string ConnectionUri => AssociatedUri;
+
+        [JsonProperty("requestedAuthenticationConfidenceLevel")]
+        public AuthenticationConfidenceLevel RequestedAuthenticationConfidenceLevel { get; } =
+            new() { Level = 400, Custom = new("VOICE_PIN")};
+    }
+}

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationConverter.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationConverter.cs
@@ -5,43 +5,44 @@ using Alexa.NET.Response.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Alexa.NET.ConnectionTasks.Inputs;
-
-public class PinConfirmationConverter : IConnectionTaskConverter
+namespace Alexa.NET.ConnectionTasks.Inputs
 {
-    private static readonly JsonSerializer Serializer = JsonSerializer.Create();
-
-    public bool CanConvert(JObject jObject)
+    public class PinConfirmationConverter : IConnectionTaskConverter
     {
-        return jObject.ContainsKey("uri") && jObject.GetValue("uri").Value<string>() == PinConfirmation.AssociatedUri;
-    }
+        private static readonly JsonSerializer Serializer = JsonSerializer.Create();
 
-    public IConnectionTask Convert(JObject jObject)
-    {
-        var task = new PinConfirmation();
-        Serializer.Populate(jObject.CreateReader(), task);
-        return task;
-    }
-
-    public static void AddToConnectionTaskConverters()
-    {
-        if (ConnectionTaskConverter.ConnectionTaskConverters.Where(rc => rc != null)
-            .All(rc => rc.GetType() != typeof(PinConfirmationConverter)))
+        public bool CanConvert(JObject jObject)
         {
-            ConnectionTaskConverter.ConnectionTaskConverters.Add(new PinConfirmationConverter());
+            return jObject.ContainsKey("uri") &&
+                   jObject.GetValue("uri").Value<string>() == PinConfirmation.AssociatedUri;
         }
-    }
 
-    public static PinConfirmationResult ResultFromSessionResumed(SessionResumedRequest request)
-    {
-        if (request.Cause.Result is not JObject jo)
+        public IConnectionTask Convert(JObject jObject)
         {
+            var task = new PinConfirmation();
+            Serializer.Populate(jObject.CreateReader(), task);
+            return task;
+        }
+
+        public static void AddToConnectionTaskConverters()
+        {
+            if (ConnectionTaskConverter.ConnectionTaskConverters.Where(rc => rc != null)
+                .All(rc => rc.GetType() != typeof(PinConfirmationConverter)))
+            {
+                ConnectionTaskConverter.ConnectionTaskConverters.Add(new PinConfirmationConverter());
+            }
+        }
+
+        public static PinConfirmationResult ResultFromSessionResumed(SessionResumedRequest request)
+        {
+            if (request.Cause.Result is JObject jo)
+            {
+                var task = new PinConfirmationResult();
+                Serializer.Populate(jo.CreateReader(), task);
+                return task;
+            }
+
             return null;
         }
-
-        var task = new PinConfirmationResult();
-        Serializer.Populate(jo.CreateReader(), task);
-        return task;
-
     }
 }

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationConverter.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using Alexa.NET.Request.Type;
+using Alexa.NET.Response.Converters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Alexa.NET.ConnectionTasks.Inputs;
+
+public class PinConfirmationConverter : IConnectionTaskConverter
+{
+    private static readonly JsonSerializer Serializer = JsonSerializer.Create();
+
+    public bool CanConvert(JObject jObject)
+    {
+        return jObject.ContainsKey("uri") && jObject.GetValue("uri").Value<string>() == PinConfirmation.AssociatedUri;
+    }
+
+    public IConnectionTask Convert(JObject jObject)
+    {
+        var task = new PinConfirmation();
+        Serializer.Populate(jObject.CreateReader(), task);
+        return task;
+    }
+
+    public static void AddToConnectionTaskConverters()
+    {
+        if (ConnectionTaskConverter.ConnectionTaskConverters.Where(rc => rc != null)
+            .All(rc => rc.GetType() != typeof(PinConfirmationConverter)))
+        {
+            ConnectionTaskConverter.ConnectionTaskConverters.Add(new PinConfirmationConverter());
+        }
+    }
+
+    public static PinConfirmationResult ResultFromSessionResumed(SessionResumedRequest request)
+    {
+        if (request.Cause.Result is not JObject jo)
+        {
+            return null;
+        }
+
+        var task = new PinConfirmationResult();
+        Serializer.Populate(jo.CreateReader(), task);
+        return task;
+
+    }
+}

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationReason.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationReason.cs
@@ -1,13 +1,13 @@
 ﻿using System.Runtime.Serialization;
 
-namespace Alexa.NET.ConnectionTasks.Inputs;
-
-public enum PinConfirmationReason
+namespace Alexa.NET.ConnectionTasks.Inputs
 {
-    [EnumMember(Value= "METHOD_LOCKOUT")]
-    MethodLockout,
-    [EnumMember(Value= "VERIFICATION_METHOD_NOT_SETUP")]
-    VerificationMethodNotSetup,
-    [EnumMember(Value= "NOT_MATCH")]
-    NotMatch
+    public enum PinConfirmationReason
+    {
+        [EnumMember(Value = "METHOD_LOCKOUT")] MethodLockout,
+
+        [EnumMember(Value = "VERIFICATION_METHOD_NOT_SETUP")]
+        VerificationMethodNotSetup,
+        [EnumMember(Value = "NOT_MATCH")] NotMatch
+    }
 }

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationReason.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationReason.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Alexa.NET.ConnectionTasks.Inputs;
+
+public enum PinConfirmationReason
+{
+    [EnumMember(Value= "METHOD_LOCKOUT")]
+    MethodLockout,
+    [EnumMember(Value= "VERIFICATION_METHOD_NOT_SETUP")]
+    VerificationMethodNotSetup,
+    [EnumMember(Value= "NOT_MATCH")]
+    NotMatch
+}

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationResult.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationResult.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alexa.NET.ConnectionTasks.Inputs
+{
+    public class PinConfirmationResult
+    {
+        [JsonProperty("status",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PinConfirmationStatus Status { get; set; }
+
+        [JsonProperty("reason",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PinConfirmationReason Reason { get; set; }
+    }
+}

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationStatus.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationStatus.cs
@@ -1,13 +1,11 @@
 ﻿using System.Runtime.Serialization;
 
-namespace Alexa.NET.ConnectionTasks.Inputs;
-
-public enum PinConfirmationStatus
+namespace Alexa.NET.ConnectionTasks.Inputs
 {
-    [EnumMember(Value="ACHIEVED")]
-    Achieved,
-    [EnumMember(Value="NOT_ACHIEVED")]
-    NotAchieved,
-    [EnumMember(Value="NOT_ENABLED")]
-    NotEnabled
+    public enum PinConfirmationStatus
+    {
+        [EnumMember(Value = "ACHIEVED")] Achieved,
+        [EnumMember(Value = "NOT_ACHIEVED")] NotAchieved,
+        [EnumMember(Value = "NOT_ENABLED")] NotEnabled
+    }
 }

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationStatus.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmationStatus.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Alexa.NET.ConnectionTasks.Inputs;
+
+public enum PinConfirmationStatus
+{
+    [EnumMember(Value="ACHIEVED")]
+    Achieved,
+    [EnumMember(Value="NOT_ACHIEVED")]
+    NotAchieved,
+    [EnumMember(Value="NOT_ENABLED")]
+    NotEnabled
+}

--- a/Alexa.NET/Request/AuthenticationConfidenceLevel.cs
+++ b/Alexa.NET/Request/AuthenticationConfidenceLevel.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Alexa.NET.Request
 {
@@ -6,5 +7,8 @@ namespace Alexa.NET.Request
     {
         [JsonProperty("level")]
         public int Level { get; set; }
+
+        [JsonProperty("customPolicy",NullValueHandling = NullValueHandling.Ignore)]
+        public AuthenticationConfidenceLevelCustomPolicy Custom { get; set; }
     }
 }

--- a/Alexa.NET/Request/AuthenticationConfidenceLevelCustomPolicy.cs
+++ b/Alexa.NET/Request/AuthenticationConfidenceLevelCustomPolicy.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class AuthenticationConfidenceLevelCustomPolicy
+    {
+        public AuthenticationConfidenceLevelCustomPolicy(){}
+
+        public AuthenticationConfidenceLevelCustomPolicy(string policyName)
+        {
+            PolicyName = policyName;
+        }
+
+        [JsonProperty("policyName")]
+        public string PolicyName { get; set; }
+    }
+}


### PR DESCRIPTION
PIN Verification is now a generally available option for skill developers, but it relies on being able to send StartConnection Directives and SessionResumedRequests sending back the result.

Although we've made this scenario extensible, this is functionality that shouldn't be difficult to implement as it's invaluable for anyone dealing with more sensitive user information.

This PR provides the model available so that asking for a pin request is a small addition to a response

```csharp
skillResponse.Response.Directives.Add(
    new StartConnectionDirective(new PinConfirmation(),"token")
);`
```

and when the user receives their token back as a SessionResumedRequest we help them get the result

```csharp
if (skillRequest.Request is SessionResumedRequest resumed && resumed.Cause.Token == "token")
{
    var pinConfirmationResult = PinConfirmationConverter.ResultFromSessionResumed(resumed);
}
```

Amazon Document: https://developer.amazon.com/en-US/docs/alexa/custom-skills/pin-confirmation-for-alexa-skills.html