### PR TITLE
C# 10 - Migrate to targeted new

### DIFF
--- a/Alexa.NET/Alexa.NET.csproj
+++ b/Alexa.NET/Alexa.NET.csproj
@@ -6,7 +6,7 @@
     <VersionPrefix>1.20.0</VersionPrefix>
     <Authors>Tim Heuer, Steven Pears</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Alexa.NET</AssemblyName>
+	  <AssemblyName>Alexa.NET</AssemblyName>
     <PackageId>Alexa.NET</PackageId>
     <PackageTags>amazon;alexa;echo;dot;echo dot;skills</PackageTags>
     <PackageReleaseNotes>Adds support for PIN confirmation support . Thanks @stoiveyp</PackageReleaseNotes>
@@ -19,7 +19,7 @@
 	  <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <LangVersion>8</LangVersion>
+    <LangVersion>10</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>

--- a/Alexa.NET/ConnectionTasks/IConnectionTaskExtensions.cs
+++ b/Alexa.NET/ConnectionTasks/IConnectionTaskExtensions.cs
@@ -10,7 +10,7 @@ namespace Alexa.NET.ConnectionTasks
 
         public static StartConnectionDirective ToConnectionDirective(this IConnectionTask task, string token = null)
         {
-            return new StartConnectionDirective(task, token);
+            return new(task, token);
         }
     }
 }

--- a/Alexa.NET/ConnectionTasks/Inputs/PinConfirmation.cs
+++ b/Alexa.NET/ConnectionTasks/Inputs/PinConfirmation.cs
@@ -13,9 +13,10 @@ namespace Alexa.NET.ConnectionTasks.Inputs
 
         [JsonProperty("requestedAuthenticationConfidenceLevel")]
         public AuthenticationConfidenceLevel RequestedAuthenticationConfidenceLevel { get; } =
-            new AuthenticationConfidenceLevel { 
+            new()
+            { 
                 Level = 400, 
-                Custom = new AuthenticationConfidenceLevelCustomPolicy("VOICE_PIN")
+                Custom = new("VOICE_PIN")
 
             };
     }

--- a/Alexa.NET/Helpers/MixedDateTimeConverter.cs
+++ b/Alexa.NET/Helpers/MixedDateTimeConverter.cs
@@ -6,7 +6,7 @@ namespace Alexa.NET.Helpers
 {
 	public class MixedDateTimeConverter : Newtonsoft.Json.Converters.DateTimeConverterBase
     {
-		static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+		static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{

--- a/Alexa.NET/Request/IntentSignature.cs
+++ b/Alexa.NET/Request/IntentSignature.cs
@@ -11,7 +11,7 @@ namespace Alexa.NET.Request
         public string Action { get; private set; }
         public System.Collections.ObjectModel.ReadOnlyDictionary<string, IntentProperty> Properties { get; private set; }
 
-		private static Regex PropertyFinder = new Regex(@"(\w+?)@(\w+?)\b(\[(\w+)\])*", RegexOptions.Compiled);
+		private static Regex PropertyFinder = new(@"(\w+?)@(\w+?)\b(\[(\w+)\])*", RegexOptions.Compiled);
 
         private IntentSignature(string fullName)
         {
@@ -89,11 +89,11 @@ namespace Alexa.NET.Request
             {
                 propertyDictionary.Add(
                     match.Groups[1].Value,
-                    new IntentProperty(match.Groups[2].Value,match.Groups[4].Value)
+                    new(match.Groups[2].Value,match.Groups[4].Value)
                 );
             }
 
-            name.Properties = new System.Collections.ObjectModel.ReadOnlyDictionary<string, IntentProperty>(propertyDictionary);
+            name.Properties = new(propertyDictionary);
         }
     }
 }

--- a/Alexa.NET/Request/RequestVerification.cs
+++ b/Alexa.NET/Request/RequestVerification.cs
@@ -61,14 +61,14 @@ namespace Alexa.NET.Request
         {
             var response = await new HttpClient().GetAsync(certificatePath);
             var bytes = await response.Content.ReadAsByteArrayAsync();
-            return new X509Certificate2(bytes);
+            return new(bytes);
         }
 
         public static bool VerifyChain(X509Certificate2 certificate)
         {
             //https://stackoverflow.com/questions/24618798/automated-downloading-of-x509-certificatePath-chain-from-remote-host
 
-            X509Chain certificateChain = new X509Chain();
+            X509Chain certificateChain = new();
             //If you do not provide revokation information, use the following line.
             certificateChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
             return certificateChain.Build(certificate);

--- a/Alexa.NET/Request/Type/ConnectionResponseTypeConverter.cs
+++ b/Alexa.NET/Request/Type/ConnectionResponseTypeConverter.cs
@@ -7,7 +7,7 @@ namespace Alexa.NET.Request.Type
 {
     public class ConnectionResponseTypeConverter : IDataDrivenRequestTypeConverter
     {
-        public static List<IConnectionResponseHandler> Handlers = new List<IConnectionResponseHandler>
+        public static List<IConnectionResponseHandler> Handlers = new()
         {
             new AskForRequestHandler()
         };

--- a/Alexa.NET/Request/Type/RequestConverter.cs
+++ b/Alexa.NET/Request/Type/RequestConverter.cs
@@ -9,7 +9,7 @@ namespace Alexa.NET.Request.Type
 {
     public class RequestConverter : JsonConverter
     {
-        public static readonly List<IRequestTypeConverter> RequestConverters = new List<IRequestTypeConverter>(new IRequestTypeConverter[]
+        public static readonly List<IRequestTypeConverter> RequestConverters = new(new IRequestTypeConverter[]
         {
             new DefaultRequestTypeConverter(),
             new AudioPlayerRequestTypeConverter(),

--- a/Alexa.NET/Response/AskForPermissionsConsentCard.cs
+++ b/Alexa.NET/Response/AskForPermissionsConsentCard.cs
@@ -15,6 +15,6 @@ namespace Alexa.NET.Response
 
         [JsonProperty("permissions")]
         [JsonRequired]
-        public List<string> Permissions { get; set; } = new List<string>();
+        public List<string> Permissions { get; set; } = new();
     }
 }

--- a/Alexa.NET/Response/Converters/CardConverter.cs
+++ b/Alexa.NET/Response/Converters/CardConverter.cs
@@ -12,7 +12,7 @@ namespace Alexa.NET.Response.Converters
 
         public override bool CanRead => true;
 
-        public static Dictionary<string, Func<ICard>> TypeFactories = new Dictionary<string, Func<ICard>>
+        public static Dictionary<string, Func<ICard>> TypeFactories = new()
         {
             { "Simple", () => new SimpleCard() },
             { "Standard", () => new StandardCard() },
@@ -33,7 +33,7 @@ namespace Alexa.NET.Response.Converters
             var hasFactory = TypeFactories.ContainsKey(typeValue);
 
             if (!hasFactory)
-                throw new Exception(
+                throw new(
                     $"unable to deserialize response. " +
                     $"unrecognized card type '{typeValue}'"
                 );

--- a/Alexa.NET/Response/Converters/ConnectionTaskConverter.cs
+++ b/Alexa.NET/Response/Converters/ConnectionTaskConverter.cs
@@ -11,7 +11,7 @@ namespace Alexa.NET.Response.Converters
 {
     public class ConnectionTaskConverter : JsonConverter
     {
-        public static Dictionary<string, Func<IConnectionTask>> TaskFactoryFromUri = new Dictionary<string, Func<IConnectionTask>>
+        public static Dictionary<string, Func<IConnectionTask>> TaskFactoryFromUri = new()
         {
             {"PrintPDFRequest/1",() => new PrintPdfV1() },
             {"PrintImageRequest/1", () => new PrintImageV1() },
@@ -20,7 +20,7 @@ namespace Alexa.NET.Response.Converters
             {"ScheduleFoodEstablishmentReservationRequest/1",() => new ScheduleFoodEstablishmentReservation()}
         };
 
-        public static readonly List<IConnectionTaskConverter> ConnectionTaskConverters = new List<IConnectionTaskConverter>();
+        public static readonly List<IConnectionTaskConverter> ConnectionTaskConverters = new();
 
         public override bool CanRead => true;
         public override bool CanWrite => false;
@@ -49,7 +49,7 @@ namespace Alexa.NET.Response.Converters
                 // Check task converters
                 var converter = ConnectionTaskConverters.FirstOrDefault(c => c.CanConvert(jsonObject));
                 if(converter is null) 
-                    throw new Exception(
+                    throw new(
                          $"unable to deserialize response. " +
                          $"unrecognized task type '{typeKey}' with version '{versionKey}'"
                      );

--- a/Alexa.NET/Response/Converters/DirectiveConverter.cs
+++ b/Alexa.NET/Response/Converters/DirectiveConverter.cs
@@ -12,7 +12,7 @@ namespace Alexa.NET.Response.Converters
 
         public override bool CanWrite => false;
 
-        public static Dictionary<string, Func<IDirective>> TypeFactories = new Dictionary<string, Func<IDirective>>
+        public static Dictionary<string, Func<IDirective>> TypeFactories = new()
         {
             { "AudioPlayer.Play", () => new AudioPlayerPlayDirective() },
             { "AudioPlayer.ClearQueue", () => new ClearQueueDirective() },
@@ -30,7 +30,7 @@ namespace Alexa.NET.Response.Converters
         };
 
         public static Dictionary<string, Func<JObject, IDirective>> DataDrivenTypeFactory =
-            new Dictionary<string, Func<JObject, IDirective>>
+            new()
             {
                 {"Connections.SendRequest", ConnectionSendRequestFactory.Create}
             };

--- a/Alexa.NET/Response/Converters/OutputSpeechConverter.cs
+++ b/Alexa.NET/Response/Converters/OutputSpeechConverter.cs
@@ -12,7 +12,7 @@ namespace Alexa.NET.Response.Converters
 
         public override bool CanWrite => false;
 
-        public static Dictionary<string, Func<IOutputSpeech>> TypeFactories = new Dictionary<string, Func<IOutputSpeech>>
+        public static Dictionary<string, Func<IOutputSpeech>> TypeFactories = new()
         {
             { "SSML", () => new SsmlOutputSpeech() },
             { "PlainText", () => new PlainTextOutputSpeech() },
@@ -31,7 +31,7 @@ namespace Alexa.NET.Response.Converters
             var hasFactory = TypeFactories.ContainsKey(typeValue);
 
             if (!hasFactory)
-                throw new Exception(
+                throw new(
                     $"unable to deserialize response. " +
                     $"unrecognized output speech type '{typeValue}'"
                 );

--- a/Alexa.NET/Response/Converters/TemplateConverter.cs
+++ b/Alexa.NET/Response/Converters/TemplateConverter.cs
@@ -14,7 +14,7 @@ namespace Alexa.NET.Response.Converters
 
         public override bool CanWrite => false;
 
-        public static Dictionary<string, Func<ITemplate>> TypeFactories = new Dictionary<string, Func<ITemplate>>
+        public static Dictionary<string, Func<ITemplate>> TypeFactories = new()
         {
             { "BodyTemplate1", () => new BodyTemplate1() },
             { "BodyTemplate2", () => new BodyTemplate2() },
@@ -38,7 +38,7 @@ namespace Alexa.NET.Response.Converters
             var hasFactory = TypeFactories.ContainsKey(typeValue);
 
             if (!hasFactory)
-                throw new Exception(
+                throw new(
                     $"unable to deserialize response. " +
                     $"unrecognized template type '{typeValue}'"
                 );

--- a/Alexa.NET/Response/Directive/AskForPermissionDirective.cs
+++ b/Alexa.NET/Response/Directive/AskForPermissionDirective.cs
@@ -9,7 +9,7 @@
 
         public AskForPermissionDirective(string permissionScope)
         {
-            this.Payload = new AskForPermissionPayload(permissionScope);
+            this.Payload = new(permissionScope);
         }
     }
 }

--- a/Alexa.NET/Response/Directive/AudioItemMetadata.cs
+++ b/Alexa.NET/Response/Directive/AudioItemMetadata.cs
@@ -12,9 +12,9 @@ namespace Alexa.NET.Response.Directive
 		public string Subtitle { get; set; }
 
 		[JsonProperty("art")]
-		public AudioItemSources Art { get; set; } = new AudioItemSources();
+		public AudioItemSources Art { get; set; } = new();
 
 		[JsonProperty("backgroundImage")]
-		public AudioItemSources BackgroundImage { get; set; } = new AudioItemSources();
+		public AudioItemSources BackgroundImage { get; set; } = new();
     }
 }

--- a/Alexa.NET/Response/Directive/AudioItemSources.cs
+++ b/Alexa.NET/Response/Directive/AudioItemSources.cs
@@ -6,6 +6,6 @@ namespace Alexa.NET.Response.Directive
     public class AudioItemSources
     {
 		[JsonProperty("sources")]
-		public List<AudioItemSource> Sources { get; set; } = new List<AudioItemSource>();
+		public List<AudioItemSource> Sources { get; set; } = new();
     }
 }

--- a/Alexa.NET/Response/Directive/CompleteTaskDirective.cs
+++ b/Alexa.NET/Response/Directive/CompleteTaskDirective.cs
@@ -12,7 +12,7 @@ namespace Alexa.NET.Response.Directive
 
         public CompleteTaskDirective(int statusCode, string statusMessage)
         {
-            Status = new ConnectionStatus(statusCode,statusMessage);
+            Status = new(statusCode,statusMessage);
         }
 
         [JsonProperty("type")]

--- a/Alexa.NET/Response/Directive/ConnectionsSendRequestFactory.cs
+++ b/Alexa.NET/Response/Directive/ConnectionsSendRequestFactory.cs
@@ -7,7 +7,7 @@ namespace Alexa.NET.Response.Directive
 {
     public static class ConnectionSendRequestFactory
     {
-        public static List<IConnectionSendRequestHandler> Handlers = new List<IConnectionSendRequestHandler>
+        public static List<IConnectionSendRequestHandler> Handlers = new()
         {
             new AskForPermissionDirectiveHandler()
         };

--- a/Alexa.NET/Response/Directive/DialogUpdateDynamicEntities.cs
+++ b/Alexa.NET/Response/Directive/DialogUpdateDynamicEntities.cs
@@ -13,6 +13,6 @@ namespace Alexa.NET.Response.Directive
         public UpdateBehavior UpdateBehavior { get; set; }
 
         [JsonProperty("types")]
-        public List<SlotType> Types { get; set; } = new List<SlotType>();
+        public List<SlotType> Types { get; set; } = new();
     }
 }

--- a/Alexa.NET/Response/Directive/HintDirective.cs
+++ b/Alexa.NET/Response/Directive/HintDirective.cs
@@ -11,7 +11,7 @@ namespace Alexa.NET.Response.Directive
 
         public HintDirective(string hintText, string textType = TextType.Plain)
         {
-            Hint = new Hint(hintText, textType);
+            Hint = new(hintText, textType);
         }
 
         [JsonProperty("type")]

--- a/Alexa.NET/Response/Directive/JsonDirective.cs
+++ b/Alexa.NET/Response/Directive/JsonDirective.cs
@@ -18,6 +18,6 @@ namespace Alexa.NET.Response.Directive
         public string Type { get; }
 
         [JsonExtensionData]
-        public Dictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+        public Dictionary<string, object> Properties { get; set; } = new();
     }
 }

--- a/Alexa.NET/Response/Directive/Templates/TemplateImage.cs
+++ b/Alexa.NET/Response/Directive/Templates/TemplateImage.cs
@@ -9,6 +9,6 @@ namespace Alexa.NET.Response.Directive.Templates
         public string ContentDescription { get; set; }
 
         [JsonProperty("sources")]
-        public List<ImageSource> Sources {get;set;} = new List<ImageSource>();
+        public List<ImageSource> Sources {get;set;} = new();
     }
 }

--- a/Alexa.NET/Response/Directive/Templates/Types/ListTemplate1.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/ListTemplate1.cs
@@ -20,7 +20,7 @@ namespace Alexa.NET.Response.Directive.Templates.Types
         [JsonProperty("backgroundImage", NullValueHandling = NullValueHandling.Ignore)]
         public TemplateImage BackgroundImage { get; set; }
 
-        public List<ListItem> Items { get; set; } = new List<ListItem>();
+        public List<ListItem> Items { get; set; } = new();
 
         public bool ShouldSerializeItems()
         {

--- a/Alexa.NET/Response/Directive/Templates/Types/ListTemplate2.cs
+++ b/Alexa.NET/Response/Directive/Templates/Types/ListTemplate2.cs
@@ -20,7 +20,7 @@ namespace Alexa.NET.Response.Directive.Templates.Types
         [JsonProperty("backgroundImage", NullValueHandling = NullValueHandling.Ignore)]
         public TemplateImage BackgroundImage { get; set; }
 
-        public List<ListItem> Items { get; set; } = new List<ListItem>();
+        public List<ListItem> Items { get; set; } = new();
 
         public bool ShouldSerializeItems()
         {

--- a/Alexa.NET/Response/Directive/VideoAppDirective.cs
+++ b/Alexa.NET/Response/Directive/VideoAppDirective.cs
@@ -10,7 +10,7 @@ namespace Alexa.NET.Response.Directive
 
         public VideoAppDirective(string source)
         {
-            VideoItem = new VideoItem(source);
+            VideoItem = new(source);
         }
 
         [JsonProperty("type")]

--- a/Alexa.NET/Response/ProgressiveResponse.cs
+++ b/Alexa.NET/Response/ProgressiveResponse.cs
@@ -22,7 +22,7 @@ namespace Alexa.NET.Response
         }
 
 
-        public ProgressiveResponse(SkillRequest request) : this(request, new HttpClient())
+        public ProgressiveResponse(SkillRequest request) : this(request, new())
         {
             
         }
@@ -34,7 +34,7 @@ namespace Alexa.NET.Response
         {
         }
 
-        public ProgressiveResponse(string requestId, string authToken, string baseAddress):this(requestId,authToken,baseAddress,new HttpClient())
+        public ProgressiveResponse(string requestId, string authToken, string baseAddress):this(requestId,authToken,baseAddress,new())
         {
 
         }
@@ -44,17 +44,17 @@ namespace Alexa.NET.Response
             Client = client;
             if (!string.IsNullOrWhiteSpace(baseAddress))
             {
-                Client.BaseAddress = new Uri(baseAddress, UriKind.Absolute);
+                Client.BaseAddress = new(baseAddress, UriKind.Absolute);
             }
 
             if (!string.IsNullOrWhiteSpace(authToken))
             {
-                Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+                Client.DefaultRequestHeaders.Authorization = new("Bearer", authToken);
             }
 
             if (!string.IsNullOrWhiteSpace(requestId))
             {
-                Header = new ProgressiveResponseHeader(requestId);
+                Header = new(requestId);
             }
         }
 

--- a/Alexa.NET/Response/Ssml/AmazonDomain.cs
+++ b/Alexa.NET/Response/Ssml/AmazonDomain.cs
@@ -9,7 +9,7 @@ namespace Alexa.NET.Response.Ssml
     {
         public string Name { get; set; }
 
-        public List<ISsml> Elements { get; set; } = new List<ISsml>();
+        public List<ISsml> Elements { get; set; } = new();
 
         public AmazonDomain(string name)
         {

--- a/Alexa.NET/Response/Ssml/AmazonEmotion.cs
+++ b/Alexa.NET/Response/Ssml/AmazonEmotion.cs
@@ -11,7 +11,7 @@ namespace Alexa.NET.Response.Ssml
 
         public string Intensity { get; set; }
 
-        public List<ISsml> Elements { get; set; } = new List<ISsml>();
+        public List<ISsml> Elements { get; set; } = new();
 
         public AmazonEmotion(string name, string intensity)
         {

--- a/Alexa.NET/Response/Ssml/Audio.cs
+++ b/Alexa.NET/Response/Ssml/Audio.cs
@@ -8,7 +8,7 @@ namespace Alexa.NET.Response.Ssml
     public class Audio:ISsml
     {
         public string Source { get; set; }
-        public List<ISsml> Elements { get; set; } = new List<ISsml>();
+        public List<ISsml> Elements { get; set; } = new();
 
         public Audio() { }
 

--- a/Alexa.NET/Response/Ssml/Break.cs
+++ b/Alexa.NET/Response/Ssml/Break.cs
@@ -11,15 +11,15 @@ namespace Alexa.NET.Response.Ssml
 
         public XNode ToXml()
         {
-            List<XAttribute> attributes = new List<XAttribute>();
+            List<XAttribute> attributes = new();
             if (!string.IsNullOrWhiteSpace(Time))
             {
-                attributes.Add(new XAttribute("time", Time));
+                attributes.Add(new("time", Time));
             }
 
             if (!string.IsNullOrWhiteSpace(Strength))
             {
-                attributes.Add(new XAttribute("strength",Strength));
+                attributes.Add(new("strength",Strength));
             }
             return new XElement("break", attributes);
         }

--- a/Alexa.NET/Response/Ssml/Emphasis.cs
+++ b/Alexa.NET/Response/Ssml/Emphasis.cs
@@ -16,7 +16,7 @@ namespace Alexa.NET.Response.Ssml
 
         public XNode ToXml()
         {
-            List<XObject> objects = new List<XObject>();
+            List<XObject> objects = new();
 
             if (!string.IsNullOrWhiteSpace(Level))
             {

--- a/Alexa.NET/Response/Ssml/Lang.cs
+++ b/Alexa.NET/Response/Ssml/Lang.cs
@@ -10,7 +10,7 @@ namespace Alexa.NET.Response.Ssml
     {
         public string LanguageCode { get; set; }
 
-        public List<ISsml> Elements { get; set; } = new List<ISsml>();
+        public List<ISsml> Elements { get; set; } = new();
 
         public Lang(string languageCode)
         {

--- a/Alexa.NET/Response/Ssml/Paragraph.cs
+++ b/Alexa.NET/Response/Ssml/Paragraph.cs
@@ -7,7 +7,7 @@ namespace Alexa.NET.Response.Ssml
 {
     public class Paragraph : ISsml
     {
-        public List<IParagraphSsml> Elements {get;set;} = new List<IParagraphSsml>();
+        public List<IParagraphSsml> Elements {get;set;} = new();
 
         public Paragraph() { }
 

--- a/Alexa.NET/Response/Ssml/Prosody.cs
+++ b/Alexa.NET/Response/Ssml/Prosody.cs
@@ -17,11 +17,11 @@ namespace Alexa.NET.Response.Ssml
             Elements = elements.ToList();
         }
 
-        public List<ISsml> Elements { get; set; } = new List<ISsml>();
+        public List<ISsml> Elements { get; set; } = new();
 
         public XNode ToXml()
         {
-            List<XObject> attributes = new List<XObject>();
+            List<XObject> attributes = new();
 
             if(!string.IsNullOrWhiteSpace(Rate))
             {

--- a/Alexa.NET/Response/Ssml/SayAs.cs
+++ b/Alexa.NET/Response/Ssml/SayAs.cs
@@ -28,7 +28,7 @@ namespace Alexa.NET.Response.Ssml
 
         public XNode ToXml()
         {
-            List<XObject> objects = new List<XObject>();
+            List<XObject> objects = new();
 
             objects.Add(new XText(Text));
             objects.Add(new XAttribute("interpret-as", InterpretAs));

--- a/Alexa.NET/Response/Ssml/Sentence.cs
+++ b/Alexa.NET/Response/Ssml/Sentence.cs
@@ -16,7 +16,7 @@ namespace Alexa.NET.Response.Ssml
             Elements = elements.ToList();
         }
 
-    public List<ISentenceSsml> Elements { get; set; } = new List<ISentenceSsml>();
+    public List<ISentenceSsml> Elements { get; set; } = new();
 
         public XNode ToXml()
         {

--- a/Alexa.NET/Response/Ssml/Speech.cs
+++ b/Alexa.NET/Response/Ssml/Speech.cs
@@ -17,7 +17,7 @@ namespace Alexa.NET.Response.Ssml
 	        Elements = elements.ToList();
 	    }
 
-	    public List<ISsml> Elements { get; set; } = new List<ISsml>();
+	    public List<ISsml> Elements { get; set; } = new();
 
 
 		public string ToXml()
@@ -27,7 +27,7 @@ namespace Alexa.NET.Response.Ssml
 				throw new InvalidOperationException("No text available");
 			}
 
-            XElement root = new XElement("speak", 
+            XElement root = new("speak", 
                 new XAttribute(XNamespace.Xmlns + "amazon", Namespaces.TempAmazon),
                 new XAttribute(XNamespace.Xmlns + "alexa",Namespaces.TempAlexa));
             root.Add(Elements.Select(e => e.ToXml()));

--- a/Alexa.NET/Response/Ssml/Voice.cs
+++ b/Alexa.NET/Response/Ssml/Voice.cs
@@ -10,7 +10,7 @@ namespace Alexa.NET.Response.Ssml
     {
         public string Name { get; set; }
 
-        public List<ISsml> Elements { get; set; } = new List<ISsml>();
+        public List<ISsml> Elements { get; set; } = new();
 
         public Voice(string name)
         {

--- a/Alexa.NET/Response/Ssml/Word.cs
+++ b/Alexa.NET/Response/Ssml/Word.cs
@@ -27,7 +27,7 @@ namespace Alexa.NET.Response.Ssml
 
         public XNode ToXml()
         {
-            List<XObject> objects = new List<XObject>();
+            List<XObject> objects = new();
 
             objects.Add(new XAttribute("role", Role));
             objects.Add(new XText(Text));

--- a/Alexa.NET/ResponseBuilder.cs
+++ b/Alexa.NET/ResponseBuilder.cs
@@ -71,7 +71,7 @@ namespace Alexa.NET
 
         public static SkillResponse TellWithCard(IOutputSpeech speechResponse, string title, string content)
         {
-            SimpleCard card = new SimpleCard();
+            SimpleCard card = new();
             card.Content = content;
             card.Title = title;
 
@@ -90,7 +90,7 @@ namespace Alexa.NET
 
         public static SkillResponse TellWithCard(IOutputSpeech speechResponse, string title, string content, Session sessionAttributes)
         {
-            SimpleCard card = new SimpleCard
+            SimpleCard card = new()
             {
                 Content = content,
                 Title = title
@@ -111,7 +111,7 @@ namespace Alexa.NET
 
         public static SkillResponse TellWithLinkAccountCard(IOutputSpeech speechResponse)
         {
-            LinkAccountCard card = new LinkAccountCard();
+            LinkAccountCard card = new();
 
             return BuildResponse(speechResponse, true, null, null, card);
         }
@@ -128,7 +128,7 @@ namespace Alexa.NET
 
         public static SkillResponse TellWithLinkAccountCard(IOutputSpeech speechResponse, Session sessionAttributes)
         {
-            LinkAccountCard card = new LinkAccountCard();
+            LinkAccountCard card = new();
 
             return BuildResponse(speechResponse, true, sessionAttributes, null, card);
         }
@@ -145,7 +145,7 @@ namespace Alexa.NET
 
         public static SkillResponse TellWithAskForPermissionsConsentCard(IOutputSpeech speechResponse, IEnumerable<string> permissions)
         {
-            AskForPermissionsConsentCard card = new AskForPermissionsConsentCard {Permissions = permissions.ToList()};
+            AskForPermissionsConsentCard card = new() {Permissions = permissions.ToList()};
             return BuildResponse(speechResponse, true, null, null, card);
         }
 
@@ -161,7 +161,7 @@ namespace Alexa.NET
 
         public static SkillResponse TellWithAskForPermissionsConsentCard(IOutputSpeech speechResponse, IEnumerable<string> permissions, Session sessionAttributes)
         {
-            AskForPermissionsConsentCard card = new AskForPermissionsConsentCard {Permissions = permissions.ToList()};
+            AskForPermissionsConsentCard card = new() {Permissions = permissions.ToList()};
             return BuildResponse(speechResponse, true, sessionAttributes, null, card);
         }
 
@@ -225,7 +225,7 @@ namespace Alexa.NET
 
         public static SkillResponse AskWithCard(IOutputSpeech speechResponse, string title, string content, Reprompt reprompt, Session sessionAttributes)
         {
-            SimpleCard card = new SimpleCard
+            SimpleCard card = new()
             {
                 Content = content,
                 Title = title
@@ -263,9 +263,9 @@ namespace Alexa.NET
             response.Response.Directives.Add(new AudioPlayerPlayDirective()
             {
                 PlayBehavior = playBehavior,
-                AudioItem = new AudioItem()
+                AudioItem = new()
                 {
-                    Stream = new AudioItemStream()
+                    Stream = new()
                     {
                         Url = url,
                         Token = token,
@@ -357,10 +357,10 @@ namespace Alexa.NET
         #region Main Response Builder
         private static SkillResponse BuildResponse(IOutputSpeech outputSpeech, bool shouldEndSession, Session sessionAttributes, Reprompt reprompt, ICard card)
         {
-            SkillResponse response = new SkillResponse {Version = "1.0"};
+            SkillResponse response = new() {Version = "1.0"};
             if (sessionAttributes != null) response.SessionAttributes = sessionAttributes.Attributes;
 
-            ResponseBody body = new ResponseBody
+            ResponseBody body = new()
             {
                 ShouldEndSession = shouldEndSession,
                 OutputSpeech = outputSpeech


### PR DESCRIPTION
Resolves #242 
Updates language version to 10
Updates object creation to targeted `new()` syntax.

Mostly newing up List and Dictionary properties, or object setup in constructors. Because of this don't think any of them lose readability with the new syntax.

Haven't changed test project - didn't want to affect the tests while the project was migrating.