### PR TITLE
AB Testing changes to Skill request/response

### DIFF
--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -42,6 +42,12 @@
     <None Update="Examples\DisplayRenderTemplateDirective.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\ExperimentationResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Examples\ExperimentationRequest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\Geolocation.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Alexa.NET.Tests/Examples/ExperimentationRequest.json
+++ b/Alexa.NET.Tests/Examples/ExperimentationRequest.json
@@ -1,0 +1,38 @@
+﻿{
+  "version": "1.0",
+  "session": {},
+  "context": {
+    "experimentation": {
+      "activeExperiments": [
+        {
+          "id": "Experiment ID",
+          "assignedVariant": {
+            "name": "TREATMENT_1"
+          }
+        }
+      ]
+    }
+  },
+  "request": {
+    "type": "IntentRequest",
+    "dialogState": "IN_PROGRESS",
+    "requestId": " amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "locale": null,
+    "intent": {
+      "name": "GetZodiacHoroscopeIntent",
+      "confirmationStatus": "DENIED",
+      "slots": {
+        "ZodiacSign": {
+          "name": "ZodiacSign",
+          "value": "virgo"
+        },
+        "Date": {
+          "name": "Date",
+          "value": "2015-11-25",
+          "confirmationStatus": "CONFIRMED"
+        }
+      }
+    }
+  }
+}

--- a/Alexa.NET.Tests/Examples/ExperimentationResponse.json
+++ b/Alexa.NET.Tests/Examples/ExperimentationResponse.json
@@ -1,0 +1,9 @@
+﻿{
+  "version": "1.0",
+  "response": {
+    "shouldEndSession": true,
+    "experimentation": {
+      "triggeredExperiments": [ "Experiment Id from request payload" ]
+    }
+  }
+}

--- a/Alexa.NET.Tests/RequestTests.cs
+++ b/Alexa.NET.Tests/RequestTests.cs
@@ -359,6 +359,16 @@ namespace Alexa.NET.Tests
             Assert.Equal("amzn1.alexa.endpoint.AABBCC010101010101010101",request.Context.System.Device.PersistentEndpointID);
         }
 
+        [Fact]
+        public void HandleExperimentationInformation()
+        {
+            var request = GetObjectFromExample<SkillRequest>("ExperimentationRequest.json");
+            Assert.NotNull(request.Context.Experimentation);
+            var experiment = Assert.Single(request.Context.Experimentation.ActiveExperiments);
+            Assert.Equal("Experiment ID", experiment.ID);
+            Assert.Equal("TREATMENT_1", experiment.AssignedVariant.Name);
+        }
+
         private T GetObjectFromExample<T>(string filename)
         {
             var json = File.ReadAllText(Path.Combine(ExamplesPath, filename));

--- a/Alexa.NET.Tests/ResponseTests.cs
+++ b/Alexa.NET.Tests/ResponseTests.cs
@@ -854,6 +854,14 @@ namespace Alexa.NET.Tests
             Assert.True(tell.Response.ShouldEndSession);
         }
 
+        [Fact]
+        public void ExperimentationSerializesCorrectly()
+        {
+            var response = ResponseBuilder.Empty();
+            response.Response.Experimentation = new ResponseExperimentation("Experiment Id from request payload");
+            Assert.True(Utility.CompareJson(response, "ExperimentationResponse.json"));
+        }
+
         private class FakeDirective : IEndSessionDirective
         {
             public string Type => "fake";

--- a/Alexa.NET/Request/Context.cs
+++ b/Alexa.NET/Request/Context.cs
@@ -16,5 +16,8 @@ namespace Alexa.NET.Request
 
         [JsonProperty("Geolocation")]
         public Geolocation Geolocation { get; set; }
+
+        [JsonProperty("experimentation",NullValueHandling = NullValueHandling.Ignore)]
+        public RequestExperimentation Experimentation { get; set; }
     }
 }

--- a/Alexa.NET/Request/Experiment.cs
+++ b/Alexa.NET/Request/Experiment.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class Experiment
+    {
+        [JsonProperty("id")]
+        public string ID { get; set; }
+
+        [JsonProperty("assignedVariant",NullValueHandling = NullValueHandling.Ignore)]
+        public ExperimentVariant AssignedVariant { get; set; }
+    }
+}

--- a/Alexa.NET/Request/ExperimentVariant.cs
+++ b/Alexa.NET/Request/ExperimentVariant.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class ExperimentVariant
+    {
+        [JsonProperty("name",NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; set; }
+    }
+}

--- a/Alexa.NET/Request/RequestExperimentation.cs
+++ b/Alexa.NET/Request/RequestExperimentation.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Alexa.NET.Request
+{
+    public class RequestExperimentation
+    {
+        [JsonProperty("activeExperiments",NullValueHandling = NullValueHandling.Ignore)]
+        public Experiment[] ActiveExperiments { get; set; }
+    }
+}

--- a/Alexa.NET/Response/Response.cs
+++ b/Alexa.NET/Response/Response.cs
@@ -44,6 +44,9 @@ namespace Alexa.NET.Response
         [JsonProperty("directives", NullValueHandling = NullValueHandling.Ignore)]
         public IList<IDirective> Directives { get; set; } = new List<IDirective>();
 
+        [JsonProperty("experimentation",NullValueHandling = NullValueHandling.Ignore)]
+        public ResponseExperimentation Experimentation { get; set; }
+
         public bool ShouldSerializeDirectives()
         {
             return Directives.Count > 0;

--- a/Alexa.NET/Response/ResponseExperimentation.cs
+++ b/Alexa.NET/Response/ResponseExperimentation.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Alexa.NET.Response
+{
+    public class ResponseExperimentation
+    {
+        public ResponseExperimentation()
+        {
+
+        }
+
+        public ResponseExperimentation(params string[] experimentIds)
+        {
+            TriggeredExperiments = experimentIds.ToList();
+        }
+
+        [JsonProperty("triggeredExperiments")]
+        public List<string> TriggeredExperiments { get; set; } = new List<string>();
+    }
+}


### PR DESCRIPTION
Amazon have introduced A/B testing into custom skills
These changes allow developers to get/send the necessary A/B testing fields for their skill as opt-in properties

Documentation:
Blog Article: https://developer.amazon.com/en-US/docs/alexa/custom-skills/a-b-test-your-skill.html
Request and response example: https://developer.amazon.com/en-US/docs/alexa/custom-skills/set-up-a-b-test.html#step-2

(I'll be updating the SMAPI extension soon so developers can manage their A/B testing in .NET too)