### PR TITLE
Made TellWithAskForPermissionsConsentCard method name consistent

### DIFF
--- a/Alexa.NET/ResponseBuilder.cs
+++ b/Alexa.NET/ResponseBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Alexa.NET.Request;
+﻿using System;
+using Alexa.NET.Request;
 using Alexa.NET.Response;
 using Alexa.NET.Response.Directive;
 using System.Collections.Generic;
@@ -149,12 +150,24 @@ namespace Alexa.NET
             return BuildResponse(speechResponse, true, null, null, card);
         }
 
+        [Obsolete("Use TellWithAskForPermissionsConsentCard instead.")]
         public static SkillResponse TellWithAskForPermissionConsentCard(string speechResponse, IEnumerable<string> permissions)
         {
             return TellWithAskForPermissionsConsentCard(new PlainTextOutputSpeech { Text = speechResponse },permissions);
         }
 
+        [Obsolete("Use TellWithAskForPermissionsConsentCard instead.")]
         public static SkillResponse TellWithAskForPermissionConsentCard(Response.Ssml.Speech speechResponse, IEnumerable<string> permissions)
+        {
+            return TellWithAskForPermissionsConsentCard(new SsmlOutputSpeech { Ssml = speechResponse.ToXml() },permissions);
+        }
+        
+        public static SkillResponse TellWithAskForPermissionsConsentCard(string speechResponse, IEnumerable<string> permissions)
+        {
+            return TellWithAskForPermissionsConsentCard(new PlainTextOutputSpeech { Text = speechResponse },permissions);
+        }
+
+        public static SkillResponse TellWithAskForPermissionsConsentCard(Response.Ssml.Speech speechResponse, IEnumerable<string> permissions)
         {
             return TellWithAskForPermissionsConsentCard(new SsmlOutputSpeech { Ssml = speechResponse.ToXml() },permissions);
         }


### PR DESCRIPTION
I noticed that the overloads for `TellWithAskForPermissionsConsentCard` were missing the `s` in the word Permissions. I marked the two methods that were named incorrectly as `Obsolete` so that it wouldn't break for anyone currently using them and added overloads with the same spelling.