### PR TITLE
Move to JSON.NET 13.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,12 @@ jobs:
       relnotes: ${{ steps.set_proj_version.outputs.RELNOTES }}
     name: Build and package 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v3
       with:
@@ -56,7 +59,7 @@ jobs:
       run: dotnet pack --configuration Release -o finalpackage --no-build
 
     - name: Publish artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nupkg
         path: finalpackage
@@ -78,9 +81,12 @@ jobs:
       url: https://www.nuget.org/packages/Alexa.NET/
     name: Sign and publish
     runs-on: windows-latest # using windows agent due to nuget can't sign on linux yet
+    permissions:
+      contents: read
+
     steps:
       - name: Download Package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nupkg
       
@@ -91,7 +97,7 @@ jobs:
           nuget-version: latest
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1.8.0
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
           include-prerelease: true
@@ -129,7 +135,7 @@ jobs:
             **/*.nupkg
 
       - name: Publish signed artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: signednupkg
           path: .

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -9,9 +9,12 @@ jobs:
   build:
     name: PR build and test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -1,9 +1,7 @@
 name: PR Build
 
-on:
-  pull_request:
-    branches:
-    - master
+on: [pull_request, workflow_dispatch]
+
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bld/
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
+coverage.*
 
 # NUNIT
 *.VisualState.xml

--- a/Alexa.NET.Tests/Alexa.NET.Tests.csproj
+++ b/Alexa.NET.Tests/Alexa.NET.Tests.csproj
@@ -3,12 +3,18 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
 	  <NoWarn>CS0612,CS0618</NoWarn>
+	  <CollectCoverage>true</CollectCoverage>
+	  <CoverletOutputFormat>cobertura,lcov</CoverletOutputFormat>
   </PropertyGroup>
-
+	
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Alexa.NET/Alexa.NET.csproj
+++ b/Alexa.NET/Alexa.NET.csproj
@@ -27,8 +27,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR moves to latest JSON.NET package to remove vulnerability in 12.x usage. Fixes  #263 

All tests pass.

This also updates some infra-related changes (other package updates, and CI workflow updates)